### PR TITLE
feat: add confidence scoring and outcome categories to done tool

### DIFF
--- a/internal/llm/tools.go
+++ b/internal/llm/tools.go
@@ -47,6 +47,11 @@ func (h *ToolHandler) Execute(ctx context.Context, call FunctionCall) (string, b
 			h.category = CategoryDiagnosis
 		}
 		h.confidence = intArgOrDefault(call.Args, "confidence", 50)
+		if h.confidence < 0 {
+			h.confidence = 0
+		} else if h.confidence > 100 {
+			h.confidence = 100
+		}
 		h.sensitivity = stringArgOrDefault(call.Args, "missing_information_sensitivity", "medium")
 		if h.sensitivity != "high" && h.sensitivity != "medium" && h.sensitivity != "low" {
 			h.sensitivity = "medium"

--- a/internal/llm/tools_test.go
+++ b/internal/llm/tools_test.go
@@ -1,0 +1,154 @@
+package llm
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDoneDiagnosis(t *testing.T) {
+	h := &ToolHandler{}
+	_, isDone, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{
+			"category":                        "diagnosis",
+			"confidence":                      float64(85),
+			"missing_information_sensitivity": "low",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isDone {
+		t.Fatal("expected done=true")
+	}
+	if h.DiagnosisCategory() != CategoryDiagnosis {
+		t.Errorf("category = %q, want %q", h.DiagnosisCategory(), CategoryDiagnosis)
+	}
+	if h.DiagnosisConfidence() != 85 {
+		t.Errorf("confidence = %d, want 85", h.DiagnosisConfidence())
+	}
+	if h.DiagnosisSensitivity() != "low" {
+		t.Errorf("sensitivity = %q, want %q", h.DiagnosisSensitivity(), "low")
+	}
+}
+
+func TestDoneNoFailures(t *testing.T) {
+	h := &ToolHandler{}
+	_, isDone, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{
+			"category": "no_failures",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isDone {
+		t.Fatal("expected done=true")
+	}
+	if h.DiagnosisCategory() != CategoryNoFailures {
+		t.Errorf("category = %q, want %q", h.DiagnosisCategory(), CategoryNoFailures)
+	}
+}
+
+func TestDoneNotSupported(t *testing.T) {
+	h := &ToolHandler{}
+	_, isDone, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{
+			"category": "not_supported",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isDone {
+		t.Fatal("expected done=true")
+	}
+	if h.DiagnosisCategory() != CategoryNotSupported {
+		t.Errorf("category = %q, want %q", h.DiagnosisCategory(), CategoryNotSupported)
+	}
+}
+
+func TestDoneWithNoArgs(t *testing.T) {
+	h := &ToolHandler{}
+	_, isDone, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isDone {
+		t.Fatal("expected done=true")
+	}
+	if h.DiagnosisCategory() != CategoryDiagnosis {
+		t.Errorf("category = %q, want %q", h.DiagnosisCategory(), CategoryDiagnosis)
+	}
+	if h.DiagnosisConfidence() != 50 {
+		t.Errorf("confidence = %d, want 50", h.DiagnosisConfidence())
+	}
+	if h.DiagnosisSensitivity() != "medium" {
+		t.Errorf("sensitivity = %q, want %q", h.DiagnosisSensitivity(), "medium")
+	}
+}
+
+func TestDoneWithFloat64Confidence(t *testing.T) {
+	h := &ToolHandler{}
+	_, _, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{
+			"category":                        "diagnosis",
+			"confidence":                      float64(72.8),
+			"missing_information_sensitivity": "high",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.DiagnosisConfidence() != 72 {
+		t.Errorf("confidence = %d, want 72", h.DiagnosisConfidence())
+	}
+}
+
+func TestDoneWithInvalidSensitivity(t *testing.T) {
+	h := &ToolHandler{}
+	_, _, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{
+			"category":                        "diagnosis",
+			"confidence":                      float64(60),
+			"missing_information_sensitivity": "invalid",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.DiagnosisSensitivity() != "medium" {
+		t.Errorf("sensitivity = %q, want %q", h.DiagnosisSensitivity(), "medium")
+	}
+}
+
+func TestDoneWithInvalidCategory(t *testing.T) {
+	h := &ToolHandler{}
+	_, _, err := h.Execute(context.Background(), FunctionCall{
+		Name: "done",
+		Args: map[string]any{
+			"category": "unknown_value",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.DiagnosisCategory() != CategoryDiagnosis {
+		t.Errorf("category = %q, want %q (fallback)", h.DiagnosisCategory(), CategoryDiagnosis)
+	}
+}
+
+func TestDoneSkippedCategory(t *testing.T) {
+	h := &ToolHandler{}
+	// Simulate model skipping done entirely — category stays ""
+	if h.DiagnosisCategory() != "" {
+		t.Errorf("category = %q, want empty string", h.DiagnosisCategory())
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -57,10 +57,26 @@ type FunctionDeclaration struct {
 
 // Schema describes the JSON schema for function parameters.
 type Schema struct {
-	Type       string            `json:"type"`
-	Properties map[string]Schema `json:"properties,omitempty"`
-	Required   []string          `json:"required,omitempty"`
-	Enum       []string          `json:"enum,omitempty"`
+	Type        string            `json:"type"`
+	Description string            `json:"description,omitempty"`
+	Properties  map[string]Schema `json:"properties,omitempty"`
+	Required    []string          `json:"required,omitempty"`
+	Enum        []string          `json:"enum,omitempty"`
+}
+
+// Outcome categories for the done tool.
+const (
+	CategoryDiagnosis    = "diagnosis"
+	CategoryNoFailures   = "no_failures"
+	CategoryNotSupported = "not_supported"
+)
+
+// AnalysisResult holds the final output from the agent loop.
+type AnalysisResult struct {
+	Text        string
+	Category    string // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
+	Confidence  int    // 0-100, meaningful only for "diagnosis"
+	Sensitivity string // "high", "medium", "low", meaningful only for "diagnosis"
 }
 
 // GenerationConfig controls response generation.

--- a/main.go
+++ b/main.go
@@ -112,8 +112,21 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("analysis failed: %w", err)
 	}
 
-	fmt.Println(result)
+	printResult(result)
 	return nil
+}
+
+func printResult(r *llm.AnalysisResult) {
+	if r.Category == llm.CategoryDiagnosis {
+		fmt.Printf("Confidence: %d%% (sensitivity: %s)\n\n", r.Confidence, r.Sensitivity)
+	}
+
+	fmt.Println(r.Text)
+
+	if r.Category == llm.CategoryDiagnosis && r.Confidence < 70 && r.Sensitivity == "high" {
+		fmt.Println()
+		fmt.Println("Tip: Additional data sources (backend logs, Docker state) may improve this diagnosis.")
+	}
 }
 
 func buildInitialContext(run *gh.WorkflowRun, jobs []gh.Job, artifacts []gh.Artifact) string {


### PR DESCRIPTION
## Summary

- Add structured confidence scoring (0-100) and missing information sensitivity (high/medium/low) to the agent's `done` tool
- Add explicit outcome `category` parameter: `diagnosis`, `no_failures`, `not_supported`
- Confidence line only printed for `diagnosis` category — no misleading output for passing runs or unsupported frameworks
- Progressive Disclosure tip shown when confidence < 70% and sensitivity is high

## Test plan

- [x] `go build ./...` + `go vet ./...` pass
- [x] `go test ./...` — 8 unit tests for done tool (category variants, defaults, validation)
- [x] Manual: TryGhost/Ghost → `diagnosis`, confidence 90%, sensitivity medium
- [x] Manual: carbon-design-system/carbon → `diagnosis`, confidence 85%
- [x] Manual: apache/kafka (JUnit) → `diagnosis`, confidence 100%
- [x] Piped output has no ANSI codes