### PR TITLE
ci(sonar): add CI workflow with SonarCloud integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run go vet
-        run: go vet ./...
-
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with coverage
+        run: go test -coverprofile=coverage.out ./...
+
+      - name: Upload coverage for SonarCloud
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: coverage.out
+          retention-days: 1
+
+  sonar:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 10
+    if: github.actor != 'dependabot[bot]'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v6
+        with:
+          name: coverage-report
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]
@@ -13,6 +10,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -31,6 +30,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -55,6 +56,8 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     timeout-minutes: 10
     if: github.actor != 'dependabot[bot]'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with coverage
-        run: go test -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage for SonarCloud
         uses: actions/upload-artifact@v6
@@ -75,4 +75,5 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v7
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - misspell
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*os.File).Close
+        - (io.Closer).Close
+        - os.RemoveAll
+        - os.MkdirAll
+        - (net/http.ResponseWriter).Write
+        - (*net/http.Server).Close
+        - (*net/http.Server).Shutdown
+        - (*net/http.Server).Serve
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt:
+      run: gofmt -l {staged_files} | grep '\.go$' && exit 1 || true
+      glob: "*.go"
+
+    vet:
+      run: go vet ./...
+
+    lint:
+      run: golangci-lint run --timeout=5m
+
+    test:
+      run: go test -race ./...

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -5,11 +5,11 @@ pre-commit:
       run: gofmt -l {staged_files} | grep '\.go$' && exit 1 || true
       glob: "*.go"
 
-    vet:
-      run: go vet ./...
-
     lint:
       run: golangci-lint run --timeout=5m
 
+pre-push:
+  parallel: true
+  commands:
     test:
       run: go test -race ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean run
+.PHONY: build test clean run lint setup
 
 BINARY_NAME=heisenberg
 
@@ -9,7 +9,15 @@ run: build
 	./$(BINARY_NAME) $(ARGS)
 
 test:
-	go test -v ./...
+	go test -race -v ./...
+
+lint:
+	go vet ./...
+	golangci-lint run --timeout=5m
+
+setup:
+	brew install lefthook golangci-lint
+	lefthook install
 
 clean:
 	rm -f $(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ test:
 	go test -race -v ./...
 
 lint:
-	go vet ./...
 	golangci-lint run --timeout=5m
 
 setup:

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -114,7 +114,7 @@ Be thorough but efficient. Don't fetch data you don't need.`}},
 			if handler.HasPendingTraces() {
 				traceResult := c.forceTraces(ctx, handler, step, maxIterations, verbose)
 				history = append(history, Content{
-					Role: "user",
+					Role:  "user",
 					Parts: []Part{{Text: "I also fetched the Playwright traces. Incorporate this data into your analysis:\n\n" + traceResult}},
 				})
 				continue
@@ -185,7 +185,7 @@ Be thorough but efficient. Don't fetch data you don't need.`}},
 		if done && handler.HasPendingTraces() {
 			traceResult := c.forceTraces(ctx, handler, step, maxIterations, verbose)
 			history = append(history, Content{
-				Role: "user",
+				Role:  "user",
 				Parts: []Part{{Text: "Before your final analysis, here is Playwright trace data you must incorporate:\n\n" + traceResult}},
 			})
 			// Don't set done — let the model regenerate with trace data.
@@ -252,8 +252,8 @@ func (c *Client) forceTraces(ctx context.Context, handler *ToolHandler, step, ma
 
 func (c *Client) generate(ctx context.Context, history []Content, tools []Tool, system *Content) (*GenerateResponse, error) {
 	req := GenerateRequest{
-		Contents:         history,
-		Tools:            tools,
+		Contents:          history,
+		Tools:             tools,
 		SystemInstruction: system,
 		GenerationConfig: &GenerationConfig{
 			Temperature:     0.1,
@@ -286,7 +286,7 @@ func (c *Client) generate(ctx context.Context, history []Content, tools []Tool, 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Gemini API error: %s - %s", resp.Status, string(body))
+		return nil, fmt.Errorf("gemini API error: %s - %s", resp.Status, string(body))
 	}
 
 	var result GenerateResponse

--- a/internal/playwright/playwright.go
+++ b/internal/playwright/playwright.go
@@ -19,7 +19,7 @@ func Snapshot(url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not start playwright: %w", err)
 	}
-	defer pw.Stop()
+	defer pw.Stop() //nolint:errcheck // best-effort cleanup
 
 	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
 		Headless: playwright.Bool(true),
@@ -27,7 +27,7 @@ func Snapshot(url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not launch browser: %w", err)
 	}
-	defer browser.Close()
+	defer browser.Close() //nolint:errcheck // best-effort cleanup
 
 	page, err := browser.NewPage()
 	if err != nil {
@@ -40,7 +40,7 @@ func Snapshot(url string) ([]byte, error) {
 		return nil, fmt.Errorf("could not navigate: %w", err)
 	}
 
-	page.WaitForTimeout(1000)
+	page.WaitForTimeout(1000) //nolint:staticcheck // intentional delay for page render in browser automation
 
 	// Try to expand failed test sections (common patterns in test reporters)
 	expandSelectors := []string{
@@ -56,13 +56,13 @@ func Snapshot(url string) ([]byte, error) {
 			if i >= 20 {
 				break
 			}
-			entry.Click(playwright.LocatorClickOptions{
+			entry.Click(playwright.LocatorClickOptions{ //nolint:errcheck // best-effort UI expansion
 				Timeout: playwright.Float(500),
 			})
 		}
 	}
 
-	page.WaitForTimeout(500)
+	page.WaitForTimeout(500) //nolint:staticcheck // intentional delay for click effects in browser automation
 
 	content, err := page.Locator("body").InnerText()
 	if err != nil {
@@ -186,6 +186,6 @@ func IsAvailable() bool {
 	if err != nil {
 		return false
 	}
-	pw.Stop()
+	pw.Stop() //nolint:errcheck // best-effort cleanup
 	return true
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,23 @@
+# SonarCloud Configuration
+
+# Project identification
+sonar.projectKey=kamilpajak_Heisenberg
+sonar.organization=kamilpajak
+
+# Project metadata
+sonar.projectName=Heisenberg
+
+# Source paths
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+
+# Exclusions from main analysis
+sonar.exclusions=**/*_test.go,vendor/**
+
+# Coverage
+sonar.go.coverage.reportPaths=coverage.out
+
+# Quality Gate - wait for result
+sonar.qualitygate.wait=true
+sonar.qualitygate.timeout=300

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # SonarCloud Configuration
 
 # Project identification
-sonar.projectKey=kamilpajak_Heisenberg
+sonar.projectKey=kamilpajak_heisenberg
 sonar.organization=kamilpajak
 
 # Project metadata

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,6 +14,13 @@ sonar.test.inclusions=**/*_test.go
 
 # Exclusions from main analysis
 sonar.exclusions=**/*_test.go,vendor/**
+sonar.test.exclusions=vendor/**
+
+# Exclude generated code from analysis
+sonar.go.exclusions=**/*_mock.go,**/*.pb.go,vendor/**
+
+# Exclude test files from duplication detection
+sonar.cpd.exclusions=**/*_test.go
 
 # Coverage
 sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
## Summary
- Add CI workflow with lint (go vet + golangci-lint), test with coverage, and SonarCloud analysis
- Add `sonar-project.properties` with project key `kamilpajak_Heisenberg`
- Runs on push/PR to main, skips Dependabot

## Test plan
- [ ] Verify SonarCloud project exists with key `kamilpajak_Heisenberg`
- [ ] Verify `SONAR_TOKEN` secret is set in repo settings
- [ ] Merge and confirm all 3 jobs pass on main