### PR TITLE
fix: improve reliability of agent loop

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -68,6 +68,30 @@ type Artifact struct {
 	Expired   bool   `json:"expired"`
 }
 
+// ArtifactStatus describes the availability of artifacts for a run.
+type ArtifactStatus struct {
+	Total      int
+	Expired    int
+	Available  int
+	HasUsable  bool
+	AllExpired bool
+}
+
+// CheckArtifacts analyzes artifact availability.
+func CheckArtifacts(artifacts []Artifact) ArtifactStatus {
+	status := ArtifactStatus{Total: len(artifacts)}
+	for _, a := range artifacts {
+		if a.Expired {
+			status.Expired++
+		} else {
+			status.Available++
+		}
+	}
+	status.HasUsable = status.Available > 0
+	status.AllExpired = status.Total > 0 && status.Expired == status.Total
+	return status
+}
+
 // WorkflowRun represents a GitHub Actions workflow run
 type WorkflowRun struct {
 	ID           int64  `json:"id"`
@@ -78,6 +102,7 @@ type WorkflowRun struct {
 	Event        string `json:"event"`
 	Path         string `json:"path"`
 	DisplayTitle string `json:"display_title"`
+	CreatedAt    string `json:"created_at"`
 }
 
 // Job represents a GitHub Actions job within a workflow run


### PR DESCRIPTION
## Summary

- Detect expired artifacts early and show clear error message instead of letting the agent loop fail
- Increase iteration limit from 10 to 20 with soft warning at 15
- Add duplicate tool call detection to prevent wasted iterations

## Changes

### Expired artifacts detection
- Added `CreatedAt` field to `WorkflowRun`
- Added `CheckArtifacts` helper to analyze artifact availability
- Early exit with helpful message when all artifacts are expired

### Agent loop improvements
- Increased `maxIterations` to 20 (was 10)
- Soft warning injected at iteration 15 to nudge model toward conclusion
- Duplicate call detection using tool+args hash map

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Test with repo that has expired artifacts
- [ ] Test with repo requiring many iterations