### PR TITLE
test: add coverage for expired artifacts and agent loop

### DIFF
--- a/internal/analysis/run_test.go
+++ b/internal/analysis/run_test.go
@@ -1,0 +1,32 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatRunDate_ValidRFC3339(t *testing.T) {
+	result := formatRunDate("2026-02-08T18:04:50Z")
+	assert.Equal(t, "2026-02-08", result)
+}
+
+func TestFormatRunDate_WithTimezone(t *testing.T) {
+	result := formatRunDate("2026-01-15T10:30:00+01:00")
+	assert.Equal(t, "2026-01-15", result)
+}
+
+func TestFormatRunDate_Empty(t *testing.T) {
+	result := formatRunDate("")
+	assert.Equal(t, "unknown date", result)
+}
+
+func TestFormatRunDate_InvalidFormat(t *testing.T) {
+	result := formatRunDate("not-a-date")
+	assert.Equal(t, "not-a-date", result)
+}
+
+func TestFormatRunDate_PartialDate(t *testing.T) {
+	result := formatRunDate("2026-02-08")
+	assert.Equal(t, "2026-02-08", result)
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -246,6 +246,61 @@ func TestFetchBlobsAllFail(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestCheckArtifacts_AllExpired(t *testing.T) {
+	artifacts := []Artifact{
+		{ID: 1, Name: "html-report", Expired: true},
+		{ID: 2, Name: "blob-report", Expired: true},
+	}
+
+	status := CheckArtifacts(artifacts)
+
+	assert.Equal(t, 2, status.Total)
+	assert.Equal(t, 2, status.Expired)
+	assert.Equal(t, 0, status.Available)
+	assert.False(t, status.HasUsable)
+	assert.True(t, status.AllExpired)
+}
+
+func TestCheckArtifacts_SomeExpired(t *testing.T) {
+	artifacts := []Artifact{
+		{ID: 1, Name: "html-report", Expired: true},
+		{ID: 2, Name: "blob-report", Expired: false},
+	}
+
+	status := CheckArtifacts(artifacts)
+
+	assert.Equal(t, 2, status.Total)
+	assert.Equal(t, 1, status.Expired)
+	assert.Equal(t, 1, status.Available)
+	assert.True(t, status.HasUsable)
+	assert.False(t, status.AllExpired)
+}
+
+func TestCheckArtifacts_NoneExpired(t *testing.T) {
+	artifacts := []Artifact{
+		{ID: 1, Name: "html-report", Expired: false},
+		{ID: 2, Name: "blob-report", Expired: false},
+	}
+
+	status := CheckArtifacts(artifacts)
+
+	assert.Equal(t, 2, status.Total)
+	assert.Equal(t, 0, status.Expired)
+	assert.Equal(t, 2, status.Available)
+	assert.True(t, status.HasUsable)
+	assert.False(t, status.AllExpired)
+}
+
+func TestCheckArtifacts_Empty(t *testing.T) {
+	status := CheckArtifacts(nil)
+
+	assert.Equal(t, 0, status.Total)
+	assert.Equal(t, 0, status.Expired)
+	assert.Equal(t, 0, status.Available)
+	assert.False(t, status.HasUsable)
+	assert.False(t, status.AllExpired)
+}
+
 func TestSelectAndFetch(t *testing.T) {
 	zipData := buildZip(t, map[string][]byte{
 		"report.html": []byte("<html>test</html>"),


### PR DESCRIPTION
## Summary

Add test coverage for new code introduced in PR #9 to satisfy SonarCloud quality gate.

## Changes

- **CheckArtifacts** (`github/client_test.go`): 4 tests covering all expired, some expired, none expired, empty cases
- **formatRunDate** (`analysis/run_test.go`): 5 tests covering valid RFC3339, timezone, empty, invalid format
- **callKey** (`llm/client_test.go`): 5 tests for tool call key generation
- **Duplicate detection** (`llm/client_test.go`): 2 integration tests for duplicate call blocking

## Test plan
- [x] `go test ./...` passes
- [x] Pre-commit hooks pass (fmt, lint)
- [ ] SonarCloud quality gate passes