### PR TITLE
feat: add structured RCA output for diagnoses

### DIFF
--- a/internal/analysis/tools.go
+++ b/internal/analysis/tools.go
@@ -20,11 +20,12 @@ type ToolHandler struct {
 	SnapshotHTML func([]byte) ([]byte, error)
 	Emitter      llm.ProgressEmitter
 
-	artifacts    []gh.Artifact // cached after first list
-	calledTraces bool          // whether get_test_traces has been called
-	category     string        // set by done tool
-	confidence   int           // 0-100, set by done tool
-	sensitivity  string        // "high", "medium", "low", set by done tool
+	artifacts    []gh.Artifact          // cached after first list
+	calledTraces bool                   // whether get_test_traces has been called
+	category     string                 // set by done tool
+	confidence   int                    // 0-100, set by done tool
+	sensitivity  string                 // "high", "medium", "low", set by done tool
+	rca          *llm.RootCauseAnalysis // structured RCA, set by done tool
 }
 
 // Execute dispatches a function call, returning the result string and whether
@@ -65,6 +66,12 @@ func (h *ToolHandler) handleDone(args map[string]any) (string, bool, error) {
 	if h.sensitivity != "high" && h.sensitivity != "medium" && h.sensitivity != "low" {
 		h.sensitivity = "medium"
 	}
+
+	// Parse structured RCA for diagnosis category
+	if h.category == llm.CategoryDiagnosis {
+		h.rca = llm.ParseRCAFromArgs(args)
+	}
+
 	return "", true, nil
 }
 
@@ -274,6 +281,9 @@ func (h *ToolHandler) DiagnosisConfidence() int { return h.confidence }
 // DiagnosisSensitivity returns the missing information sensitivity set by the done tool.
 func (h *ToolHandler) DiagnosisSensitivity() string { return h.sensitivity }
 
+// DiagnosisRCA returns the structured root cause analysis set by the done tool.
+func (h *ToolHandler) DiagnosisRCA() *llm.RootCauseAnalysis { return h.rca }
+
 // GetEmitter returns the progress emitter for this handler.
 func (h *ToolHandler) GetEmitter() llm.ProgressEmitter { return h.Emitter }
 
@@ -392,7 +402,7 @@ func ToolDeclarations() []llm.FunctionDeclaration {
 		},
 		{
 			Name:        "done",
-			Description: "Signal that you have gathered enough information. After calling this, provide your final analysis as text.",
+			Description: "Signal that you have gathered enough information and provide structured Root Cause Analysis. After calling this, provide your final analysis as text.",
 			Parameters: &llm.Schema{
 				Type: "object",
 				Properties: map[string]llm.Schema{
@@ -401,13 +411,46 @@ func ToolDeclarations() []llm.FunctionDeclaration {
 						Description: "The type of conclusion reached. diagnosis: a specific failure root cause was identified. no_failures: all tests are passing, no failures to diagnose. not_supported: the test framework or artifact format is not supported for analysis.",
 						Enum:        []string{"diagnosis", "no_failures", "not_supported"},
 					},
+					"title": {
+						Type:        "string",
+						Description: "Short summary of the failure (e.g., 'Timeout waiting for Submit Button'). Required for diagnosis.",
+					},
+					"failure_type": {
+						Type:        "string",
+						Description: "Type of failure: timeout (test timed out), assertion (assertion failed), network (HTTP/API error), infra (CI/environment issue), flake (intermittent/race condition).",
+						Enum:        []string{"timeout", "assertion", "network", "infra", "flake"},
+					},
+					"file_path": {
+						Type:        "string",
+						Description: "Path to the test file where failure occurred (e.g., 'tests/checkout.spec.ts').",
+					},
+					"line_number": {
+						Type:        "number",
+						Description: "Line number in the test file where failure occurred.",
+					},
+					"symptom": {
+						Type:        "string",
+						Description: "What failed - the observable error message or behavior.",
+					},
+					"root_cause": {
+						Type:        "string",
+						Description: "Why it failed - the underlying issue that caused the failure.",
+					},
+					"evidence": {
+						Type:        "array",
+						Description: "Supporting data points. Each item has 'type' (screenshot/trace/log/network/code) and 'content' (description).",
+					},
+					"remediation": {
+						Type:        "string",
+						Description: "How to fix it - actionable guidance for resolving the issue.",
+					},
 					"confidence": {
 						Type:        "number",
-						Description: "Diagnosis confidence score from 0 to 100. Only meaningful when category is 'diagnosis'. 80-100: clear root cause identified with strong evidence. 40-79: likely cause identified but some ambiguity remains. 0-39: uncertain, multiple possible causes or insufficient evidence.",
+						Description: "Diagnosis confidence score from 0 to 100. 80-100: clear root cause. 40-79: likely cause with ambiguity. 0-39: uncertain.",
 					},
 					"missing_information_sensitivity": {
 						Type:        "string",
-						Description: "How much additional data (backend logs, Docker containers, CI environment) would improve the diagnosis. Only meaningful when category is 'diagnosis'. high: additional data would likely reveal the root cause. medium: additional data might help but current evidence is reasonable. low: diagnosis is based on sufficient frontend/test evidence.",
+						Description: "How much additional data would improve the diagnosis. high: backend logs would help. medium: might help. low: sufficient evidence.",
 						Enum:        []string{"high", "medium", "low"},
 					},
 				},

--- a/internal/analysis/tools.go
+++ b/internal/analysis/tools.go
@@ -439,6 +439,13 @@ func ToolDeclarations() []llm.FunctionDeclaration {
 					"evidence": {
 						Type:        "array",
 						Description: "Supporting data points. Each item has 'type' (screenshot/trace/log/network/code) and 'content' (description).",
+						Items: &llm.Schema{
+							Type: "object",
+							Properties: map[string]llm.Schema{
+								"type":    {Type: "string", Description: "Evidence type: screenshot, trace, log, network, or code"},
+								"content": {Type: "string", Description: "Description of the evidence"},
+							},
+						},
 					},
 					"remediation": {
 						Type:        "string",

--- a/internal/analysis/tools_test.go
+++ b/internal/analysis/tools_test.go
@@ -1081,6 +1081,30 @@ func TestToolDeclarations(t *testing.T) {
 	assert.Len(t, decls, 7)
 }
 
+func TestToolDeclarations_DoneEvidenceArrayHasItems(t *testing.T) {
+	decls := ToolDeclarations()
+
+	// Find the done tool
+	var doneDecl *llm.FunctionDeclaration
+	for i := range decls {
+		if decls[i].Name == "done" {
+			doneDecl = &decls[i]
+			break
+		}
+	}
+	require.NotNil(t, doneDecl, "done tool should exist")
+	require.NotNil(t, doneDecl.Parameters, "done tool should have parameters")
+
+	// Check evidence field exists and has Items schema (required by Gemini API for arrays)
+	evidenceSchema, ok := doneDecl.Parameters.Properties["evidence"]
+	require.True(t, ok, "done tool should have evidence property")
+	assert.Equal(t, "array", evidenceSchema.Type, "evidence should be array type")
+	require.NotNil(t, evidenceSchema.Items, "evidence array MUST have Items schema for Gemini API")
+	assert.Equal(t, "object", evidenceSchema.Items.Type, "evidence items should be objects")
+	assert.Contains(t, evidenceSchema.Items.Properties, "type", "evidence items should have type property")
+	assert.Contains(t, evidenceSchema.Items.Properties, "content", "evidence items should have content property")
+}
+
 type mockEmitter struct{}
 
 func (m *mockEmitter) Emit(llm.ProgressEvent) {}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -112,20 +112,31 @@ Strategy:
 3. Focus on FAILED jobs and their logs
 4. For Playwright test failures, fetch the HTML report artifact first
 5. Use get_test_traces on test-results artifacts to get browser actions, console errors, and failed HTTP requests from Playwright trace recordings
-6. When you have enough information, you MUST call the "done" tool first, then provide your analysis text. Never skip the done tool.
+6. When you have enough information, you MUST call the "done" tool with structured RCA data, then provide your analysis text.
 
 When calling the "done" tool, classify your conclusion:
-- category "diagnosis": you identified a specific failure root cause. Include confidence (0-100) and missing_information_sensitivity.
+- category "diagnosis": you identified a specific failure root cause. Include ALL structured RCA fields.
 - category "no_failures": all tests are passing, nothing to diagnose.
 - category "not_supported": the test framework or artifact format cannot be analyzed.
 
-For "diagnosis" category:
-  Confidence scoring (0-100):
+For "diagnosis" category, provide structured Root Cause Analysis:
+  - title: Short summary (e.g., "Timeout waiting for Submit Button")
+  - failure_type: One of: timeout, assertion, network, infra, flake
+  - file_path: Test file where failure occurred (e.g., "tests/checkout.spec.ts")
+  - line_number: Line number in the test file (if known)
+  - symptom: What failed (the observable error)
+  - root_cause: Why it failed (the underlying issue)
+  - evidence: Array of supporting data points, each with type (screenshot/trace/log/network/code) and content
+  - remediation: How to fix it (actionable guidance)
+  - confidence: 0-100 score
+  - missing_information_sensitivity: high/medium/low
+
+Confidence scoring (0-100):
   - 80-100: Clear root cause identified with strong evidence
   - 40-79: Likely cause identified but some ambiguity remains
   - 0-39: Uncertain, multiple possible causes or insufficient evidence
 
-  Missing information sensitivity:
+Missing information sensitivity:
   - high: Backend logs, Docker state, or CI environment data would likely reveal the root cause
   - medium: Additional data might help but current evidence is reasonable
   - low: Diagnosis is well-supported by frontend/test evidence alone
@@ -357,6 +368,7 @@ func buildResult(texts []string, handler ToolExecutor) *AnalysisResult {
 		Category:    handler.DiagnosisCategory(),
 		Confidence:  handler.DiagnosisConfidence(),
 		Sensitivity: handler.DiagnosisSensitivity(),
+		RCA:         handler.DiagnosisRCA(),
 	}
 	if result.Category == "" {
 		result.Category = CategoryDiagnosis

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -20,7 +20,7 @@ func emit(h ToolExecutor, ev ProgressEvent) {
 	}
 }
 
-const maxIterations = 20
+const maxIterations = 30
 const softLimitIteration = 15
 
 var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -258,11 +258,12 @@ func (m *mockToolHandler) Execute(_ context.Context, call FunctionCall) (string,
 	return "unknown tool: " + call.Name, false, nil
 }
 
-func (m *mockToolHandler) HasPendingTraces() bool       { return false }
-func (m *mockToolHandler) DiagnosisCategory() string    { return m.category }
-func (m *mockToolHandler) DiagnosisConfidence() int     { return m.confidence }
-func (m *mockToolHandler) DiagnosisSensitivity() string { return m.sensitivity }
-func (m *mockToolHandler) GetEmitter() ProgressEmitter  { return m.emitter }
+func (m *mockToolHandler) HasPendingTraces() bool           { return false }
+func (m *mockToolHandler) DiagnosisCategory() string        { return m.category }
+func (m *mockToolHandler) DiagnosisConfidence() int         { return m.confidence }
+func (m *mockToolHandler) DiagnosisSensitivity() string     { return m.sensitivity }
+func (m *mockToolHandler) DiagnosisRCA() *RootCauseAnalysis { return nil }
+func (m *mockToolHandler) GetEmitter() ProgressEmitter      { return m.emitter }
 
 // testToolDeclarations returns minimal tool declarations for tests.
 func testToolDeclarations() []FunctionDeclaration {

--- a/internal/llm/rca.go
+++ b/internal/llm/rca.go
@@ -1,0 +1,162 @@
+package llm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Failure type constants for categorizing test failures.
+const (
+	FailureTypeTimeout   = "timeout"
+	FailureTypeAssertion = "assertion"
+	FailureTypeNetwork   = "network"
+	FailureTypeInfra     = "infra"
+	FailureTypeFlake     = "flake"
+)
+
+// Evidence type constants for categorizing supporting data.
+const (
+	EvidenceScreenshot = "screenshot"
+	EvidenceTrace      = "trace"
+	EvidenceLog        = "log"
+	EvidenceNetwork    = "network"
+	EvidenceCode       = "code"
+)
+
+// RootCauseAnalysis holds structured diagnosis information.
+type RootCauseAnalysis struct {
+	Title       string        `json:"title"`              // Short summary, e.g. "Timeout waiting for Submit Button"
+	FailureType string        `json:"failure_type"`       // timeout, assertion, network, infra, flake
+	Location    *CodeLocation `json:"location,omitempty"` // Where the failure occurred
+	Symptom     string        `json:"symptom"`            // What failed
+	RootCause   string        `json:"root_cause"`         // Why it failed
+	Evidence    []Evidence    `json:"evidence"`           // Supporting data points
+	Remediation string        `json:"remediation"`        // How to fix it
+}
+
+// CodeLocation identifies a specific location in source code.
+type CodeLocation struct {
+	FilePath     string `json:"file_path"`               // e.g. "tests/checkout.spec.ts"
+	LineNumber   int    `json:"line_number,omitempty"`   // e.g. 45
+	FunctionName string `json:"function_name,omitempty"` // e.g. "test('user can checkout')"
+}
+
+// Evidence represents a piece of supporting data for the diagnosis.
+type Evidence struct {
+	Type    string `json:"type"`    // screenshot, trace, log, network, code
+	Content string `json:"content"` // Description of the evidence
+}
+
+// ParseRCAFromArgs extracts RootCauseAnalysis from done tool arguments.
+func ParseRCAFromArgs(args map[string]any) *RootCauseAnalysis {
+	if args == nil {
+		return &RootCauseAnalysis{}
+	}
+
+	rca := &RootCauseAnalysis{
+		Title:       stringArg(args, "title"),
+		FailureType: stringArg(args, "failure_type"),
+		Symptom:     stringArg(args, "symptom"),
+		RootCause:   stringArg(args, "root_cause"),
+		Remediation: stringArg(args, "remediation"),
+	}
+
+	// Parse location if file_path is present
+	if filePath := stringArg(args, "file_path"); filePath != "" {
+		rca.Location = &CodeLocation{
+			FilePath:     filePath,
+			LineNumber:   intArgValue(args, "line_number"),
+			FunctionName: stringArg(args, "function_name"),
+		}
+	}
+
+	// Parse evidence array
+	if evidenceRaw, ok := args["evidence"].([]any); ok {
+		for _, ev := range evidenceRaw {
+			if evMap, ok := ev.(map[string]any); ok {
+				rca.Evidence = append(rca.Evidence, Evidence{
+					Type:    stringArg(evMap, "type"),
+					Content: stringArg(evMap, "content"),
+				})
+			}
+		}
+	}
+
+	return rca
+}
+
+// FormatForCLI returns a formatted string for CLI output.
+func (rca *RootCauseAnalysis) FormatForCLI() string {
+	var b strings.Builder
+
+	// Header with failure type and location
+	header := fmt.Sprintf("%s ERROR", strings.ToUpper(rca.FailureType))
+	if rca.Location != nil {
+		loc := rca.Location.FilePath
+		if rca.Location.LineNumber > 0 {
+			loc = fmt.Sprintf("%s:%d", rca.Location.FilePath, rca.Location.LineNumber)
+		}
+		header = fmt.Sprintf("%s in %s", header, loc)
+	}
+	b.WriteString(header)
+	b.WriteString("\n\n")
+
+	// Root cause section
+	b.WriteString("ROOT CAUSE\n")
+	b.WriteString(rca.RootCause)
+	b.WriteString("\n\n")
+
+	// Evidence section (if any)
+	if len(rca.Evidence) > 0 {
+		b.WriteString("EVIDENCE\n")
+		for _, ev := range rca.Evidence {
+			icon := evidenceIcon(ev.Type)
+			b.WriteString(fmt.Sprintf("%s %s\n", icon, ev.Content))
+		}
+		b.WriteString("\n")
+	}
+
+	// Fix section
+	b.WriteString("FIX\n")
+	b.WriteString(rca.Remediation)
+
+	return b.String()
+}
+
+// evidenceIcon returns an emoji icon for the evidence type.
+func evidenceIcon(t string) string {
+	switch t {
+	case EvidenceScreenshot:
+		return "[Screenshot]"
+	case EvidenceTrace:
+		return "[Trace]"
+	case EvidenceLog:
+		return "[Log]"
+	case EvidenceNetwork:
+		return "[Network]"
+	case EvidenceCode:
+		return "[Code]"
+	default:
+		return "[Evidence]"
+	}
+}
+
+// stringArg extracts a string from args, returning empty string if not found.
+func stringArg(args map[string]any, key string) string {
+	if v, ok := args[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// intArgValue extracts an int from args, returning 0 if not found.
+func intArgValue(args map[string]any, key string) int {
+	switch v := args[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		return 0
+	}
+}

--- a/internal/llm/rca_test.go
+++ b/internal/llm/rca_test.go
@@ -1,0 +1,332 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootCauseAnalysis_JSONSerialization(t *testing.T) {
+	rca := &RootCauseAnalysis{
+		Title:       "Timeout waiting for Submit Button",
+		FailureType: FailureTypeTimeout,
+		Location: &CodeLocation{
+			FilePath:     "tests/checkout.spec.ts",
+			LineNumber:   45,
+			FunctionName: "test('user can checkout')",
+		},
+		Symptom:   "Test timed out after 30000ms waiting for selector '#submit-btn'",
+		RootCause: "Cookie banner overlays the submit button, intercepting click events",
+		Evidence: []Evidence{
+			{Type: EvidenceScreenshot, Content: "Screenshot shows .cookie-overlay at z-index 999"},
+			{Type: EvidenceTrace, Content: "Click action blocked at 12:34:56.123"},
+		},
+		Remediation: "Close the cookie banner before interacting with the submit button",
+	}
+
+	data, err := json.Marshal(rca)
+	require.NoError(t, err)
+
+	var decoded RootCauseAnalysis
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, rca.Title, decoded.Title)
+	assert.Equal(t, rca.FailureType, decoded.FailureType)
+	assert.Equal(t, rca.Location.FilePath, decoded.Location.FilePath)
+	assert.Equal(t, rca.Location.LineNumber, decoded.Location.LineNumber)
+	assert.Equal(t, rca.Symptom, decoded.Symptom)
+	assert.Equal(t, rca.RootCause, decoded.RootCause)
+	assert.Len(t, decoded.Evidence, 2)
+	assert.Equal(t, rca.Remediation, decoded.Remediation)
+}
+
+func TestRootCauseAnalysis_MinimalValid(t *testing.T) {
+	// Minimal valid RCA - only required fields
+	rca := &RootCauseAnalysis{
+		Title:       "Test failed",
+		FailureType: FailureTypeAssertion,
+		Symptom:     "Assertion failed",
+		RootCause:   "Expected value mismatch",
+		Evidence:    []Evidence{},
+		Remediation: "Fix the expected value",
+	}
+
+	data, err := json.Marshal(rca)
+	require.NoError(t, err)
+
+	var decoded RootCauseAnalysis
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, rca.Title, decoded.Title)
+	assert.Nil(t, decoded.Location) // Optional field
+}
+
+func TestCodeLocation_JSONSerialization(t *testing.T) {
+	loc := &CodeLocation{
+		FilePath:     "src/components/Button.tsx",
+		LineNumber:   42,
+		FunctionName: "handleClick",
+	}
+
+	data, err := json.Marshal(loc)
+	require.NoError(t, err)
+
+	var decoded CodeLocation
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, loc.FilePath, decoded.FilePath)
+	assert.Equal(t, loc.LineNumber, decoded.LineNumber)
+	assert.Equal(t, loc.FunctionName, decoded.FunctionName)
+}
+
+func TestCodeLocation_WithoutOptionalFields(t *testing.T) {
+	loc := &CodeLocation{
+		FilePath: "tests/login.spec.ts",
+	}
+
+	data, err := json.Marshal(loc)
+	require.NoError(t, err)
+
+	var decoded CodeLocation
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tests/login.spec.ts", decoded.FilePath)
+	assert.Equal(t, 0, decoded.LineNumber)
+	assert.Equal(t, "", decoded.FunctionName)
+}
+
+func TestEvidence_AllTypes(t *testing.T) {
+	tests := []struct {
+		evidenceType string
+		content      string
+	}{
+		{EvidenceScreenshot, "Screenshot shows error dialog"},
+		{EvidenceTrace, "Trace shows network timeout at 5000ms"},
+		{EvidenceLog, "Error: Connection refused"},
+		{EvidenceNetwork, "HTTP 500 from /api/login"},
+		{EvidenceCode, "Line 45: await page.click('#btn')"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.evidenceType, func(t *testing.T) {
+			ev := Evidence{Type: tc.evidenceType, Content: tc.content}
+			data, err := json.Marshal(ev)
+			require.NoError(t, err)
+
+			var decoded Evidence
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.evidenceType, decoded.Type)
+			assert.Equal(t, tc.content, decoded.Content)
+		})
+	}
+}
+
+func TestAnalysisResult_WithRCA(t *testing.T) {
+	result := &AnalysisResult{
+		Category:    CategoryDiagnosis,
+		Confidence:  85,
+		Sensitivity: "low",
+		RCA: &RootCauseAnalysis{
+			Title:       "Element Interception",
+			FailureType: FailureTypeTimeout,
+			Location: &CodeLocation{
+				FilePath:   "tests/checkout.spec.ts",
+				LineNumber: 45,
+			},
+			Symptom:     "Timeout waiting for '#submit-btn'",
+			RootCause:   "Cookie banner blocks element",
+			Evidence:    []Evidence{{Type: EvidenceScreenshot, Content: "Overlay visible"}},
+			Remediation: "Dismiss cookie banner first",
+		},
+	}
+
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var decoded AnalysisResult
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, CategoryDiagnosis, decoded.Category)
+	assert.Equal(t, 85, decoded.Confidence)
+	require.NotNil(t, decoded.RCA)
+	assert.Equal(t, "Element Interception", decoded.RCA.Title)
+	assert.Equal(t, FailureTypeTimeout, decoded.RCA.FailureType)
+}
+
+func TestAnalysisResult_WithoutRCA_LegacyText(t *testing.T) {
+	// For backward compatibility: category != diagnosis should not have RCA
+	result := &AnalysisResult{
+		Text:     "All tests passing",
+		Category: CategoryNoFailures,
+	}
+
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var decoded AnalysisResult
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, CategoryNoFailures, decoded.Category)
+	assert.Equal(t, "All tests passing", decoded.Text)
+	assert.Nil(t, decoded.RCA)
+}
+
+func TestFailureType_Constants(t *testing.T) {
+	// Verify all failure type constants are defined
+	assert.Equal(t, "timeout", FailureTypeTimeout)
+	assert.Equal(t, "assertion", FailureTypeAssertion)
+	assert.Equal(t, "network", FailureTypeNetwork)
+	assert.Equal(t, "infra", FailureTypeInfra)
+	assert.Equal(t, "flake", FailureTypeFlake)
+}
+
+func TestEvidenceType_Constants(t *testing.T) {
+	// Verify all evidence type constants are defined
+	assert.Equal(t, "screenshot", EvidenceScreenshot)
+	assert.Equal(t, "trace", EvidenceTrace)
+	assert.Equal(t, "log", EvidenceLog)
+	assert.Equal(t, "network", EvidenceNetwork)
+	assert.Equal(t, "code", EvidenceCode)
+}
+
+func TestParseRCAFromArgs_Complete(t *testing.T) {
+	args := map[string]any{
+		"title":        "Timeout Error",
+		"failure_type": "timeout",
+		"file_path":    "tests/login.spec.ts",
+		"line_number":  float64(42),
+		"symptom":      "Test timed out",
+		"root_cause":   "Slow network",
+		"evidence": []any{
+			map[string]any{"type": "trace", "content": "Network delay"},
+		},
+		"remediation": "Add retry logic",
+	}
+
+	rca := ParseRCAFromArgs(args)
+
+	require.NotNil(t, rca)
+	assert.Equal(t, "Timeout Error", rca.Title)
+	assert.Equal(t, FailureTypeTimeout, rca.FailureType)
+	require.NotNil(t, rca.Location)
+	assert.Equal(t, "tests/login.spec.ts", rca.Location.FilePath)
+	assert.Equal(t, 42, rca.Location.LineNumber)
+	assert.Equal(t, "Test timed out", rca.Symptom)
+	assert.Equal(t, "Slow network", rca.RootCause)
+	require.Len(t, rca.Evidence, 1)
+	assert.Equal(t, EvidenceTrace, rca.Evidence[0].Type)
+	assert.Equal(t, "Add retry logic", rca.Remediation)
+}
+
+func TestParseRCAFromArgs_Minimal(t *testing.T) {
+	args := map[string]any{
+		"title":        "Error",
+		"failure_type": "assertion",
+		"symptom":      "Failed",
+		"root_cause":   "Bug",
+		"remediation":  "Fix it",
+	}
+
+	rca := ParseRCAFromArgs(args)
+
+	require.NotNil(t, rca)
+	assert.Equal(t, "Error", rca.Title)
+	assert.Nil(t, rca.Location)
+	assert.Empty(t, rca.Evidence)
+}
+
+func TestParseRCAFromArgs_InvalidFailureType(t *testing.T) {
+	args := map[string]any{
+		"title":        "Error",
+		"failure_type": "unknown_type",
+		"symptom":      "Failed",
+		"root_cause":   "Bug",
+		"remediation":  "Fix it",
+	}
+
+	rca := ParseRCAFromArgs(args)
+
+	require.NotNil(t, rca)
+	// Invalid type should default to empty (model can provide any value, we don't reject)
+	assert.Equal(t, "unknown_type", rca.FailureType)
+}
+
+func TestParseRCAFromArgs_MissingRequiredFields(t *testing.T) {
+	args := map[string]any{
+		"title": "Only title",
+	}
+
+	rca := ParseRCAFromArgs(args)
+
+	// Should still parse, just with empty fields
+	require.NotNil(t, rca)
+	assert.Equal(t, "Only title", rca.Title)
+	assert.Equal(t, "", rca.Symptom)
+}
+
+func TestParseRCAFromArgs_EmptyArgs(t *testing.T) {
+	rca := ParseRCAFromArgs(map[string]any{})
+
+	// Empty RCA with all defaults
+	require.NotNil(t, rca)
+	assert.Equal(t, "", rca.Title)
+}
+
+func TestParseRCAFromArgs_NilArgs(t *testing.T) {
+	rca := ParseRCAFromArgs(nil)
+
+	// Should handle nil gracefully
+	require.NotNil(t, rca)
+}
+
+func TestRCA_FormatForCLI(t *testing.T) {
+	rca := &RootCauseAnalysis{
+		Title:       "Timeout waiting for Submit Button",
+		FailureType: FailureTypeTimeout,
+		Location: &CodeLocation{
+			FilePath:   "tests/checkout.spec.ts",
+			LineNumber: 45,
+		},
+		Symptom:     "Test timed out after 30000ms",
+		RootCause:   "Cookie banner overlays submit button",
+		Evidence:    []Evidence{{Type: EvidenceScreenshot, Content: "Overlay at z=999"}},
+		Remediation: "Add cookie banner dismiss step",
+	}
+
+	formatted := rca.FormatForCLI()
+
+	assert.Contains(t, formatted, "TIMEOUT")
+	assert.Contains(t, formatted, "tests/checkout.spec.ts:45")
+	assert.Contains(t, formatted, "ROOT CAUSE")
+	assert.Contains(t, formatted, "Cookie banner overlays submit button")
+	assert.Contains(t, formatted, "EVIDENCE")
+	assert.Contains(t, formatted, "Overlay at z=999")
+	assert.Contains(t, formatted, "FIX")
+	assert.Contains(t, formatted, "Add cookie banner dismiss step")
+}
+
+func TestRCA_FormatForCLI_NoLocation(t *testing.T) {
+	rca := &RootCauseAnalysis{
+		Title:       "Network Error",
+		FailureType: FailureTypeNetwork,
+		Symptom:     "Request failed",
+		RootCause:   "Server down",
+		Evidence:    []Evidence{},
+		Remediation: "Check server status",
+	}
+
+	formatted := rca.FormatForCLI()
+
+	assert.Contains(t, formatted, "NETWORK")
+	assert.NotContains(t, formatted, ":0") // Should not show line 0
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -101,15 +101,17 @@ type ToolExecutor interface {
 	DiagnosisCategory() string
 	DiagnosisConfidence() int
 	DiagnosisSensitivity() string
+	DiagnosisRCA() *RootCauseAnalysis
 	GetEmitter() ProgressEmitter
 }
 
 // AnalysisResult holds the final output from the agent loop.
 type AnalysisResult struct {
-	Text        string `json:"text"`
-	Category    string `json:"category"`    // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
-	Confidence  int    `json:"confidence"`  // 0-100, meaningful only for "diagnosis"
-	Sensitivity string `json:"sensitivity"` // "high", "medium", "low", meaningful only for "diagnosis"
+	Text        string             `json:"text"`
+	Category    string             `json:"category"`      // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
+	Confidence  int                `json:"confidence"`    // 0-100, meaningful only for "diagnosis"
+	Sensitivity string             `json:"sensitivity"`   // "high", "medium", "low", meaningful only for "diagnosis"
+	RCA         *RootCauseAnalysis `json:"rca,omitempty"` // Structured diagnosis, only for "diagnosis"
 }
 
 // GenerationConfig controls response generation.

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -84,6 +84,7 @@ type Schema struct {
 	Properties  map[string]Schema `json:"properties,omitempty"`
 	Required    []string          `json:"required,omitempty"`
 	Enum        []string          `json:"enum,omitempty"`
+	Items       *Schema           `json:"items,omitempty"` // For array types
 }
 
 // Outcome categories for the done tool.


### PR DESCRIPTION
## Summary

- Add `RootCauseAnalysis` type with structured fields for test failure diagnosis
- Update `done` tool to parse structured RCA from LLM response
- Update system prompt to request structured RCA for diagnoses
- Add CLI rendering with evidence icons and code location
- Fall back to legacy text when RCA not available (backward compatible)

## New RCA Structure

```go
type RootCauseAnalysis struct {
    Title       string        // "Timeout waiting for Submit Button"
    FailureType string        // timeout, assertion, network, infra, flake
    Location    *CodeLocation // file:line
    Symptom     string        // What failed
    RootCause   string        // Why it failed
    Evidence    []Evidence    // Supporting data
    Remediation string        // How to fix
}
```

## CLI Output Example

```
TIMEOUT in tests/checkout.spec.ts:45

ROOT CAUSE
Cookie banner overlays submit button

EVIDENCE
[Screenshot] Overlay visible at z=999
[Trace] Click blocked at 12:34:56

FIX
Dismiss cookie banner before form submission
```

## Test plan

- [x] Unit tests for RCA types and JSON serialization
- [x] Unit tests for `ParseRCAFromArgs`
- [x] Unit tests for CLI rendering (`printStructuredRCA`)
- [x] Fallback tests for legacy text output
- [x] All existing tests pass