### PR TITLE
feat: persist CLI analysis results to SaaS dashboard

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kamilpajak/heisenberg/internal/dashboard"
 	"github.com/kamilpajak/heisenberg/pkg/analysis"
 	"github.com/kamilpajak/heisenberg/pkg/llm"
+	"github.com/kamilpajak/heisenberg/pkg/saas"
 	"github.com/kamilpajak/heisenberg/pkg/trace"
 	"github.com/spf13/cobra"
 )
@@ -96,6 +97,24 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	emitter.Close()
+
+	// Persist to SaaS dashboard (if configured)
+	if client := saas.NewClient(); client != nil {
+		id, err := client.SubmitAnalysis(context.Background(), saas.SubmitParams{
+			OrgID:     os.Getenv("HEISENBERG_ORG_ID"),
+			Owner:     owner,
+			Repo:      repoName,
+			RunID:     result.RunID,
+			Branch:    result.Branch,
+			CommitSHA: result.CommitSHA,
+			Result:    result,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to save to dashboard: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Saved to dashboard: %s/analyses/%s\n", client.BaseURL(), id)
+		}
+	}
 
 	if jsonOutput {
 		return json.NewEncoder(os.Stdout).Encode(result)

--- a/internal/api/analysis_handlers.go
+++ b/internal/api/analysis_handlers.go
@@ -3,8 +3,10 @@ package api
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/kamilpajak/heisenberg/internal/database"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
 )
 
 // handleListAnalyses returns analyses for a repository.
@@ -120,4 +122,87 @@ func parsePagination(r *http.Request) (limit, offset int) {
 	}
 
 	return limit, offset
+}
+
+// handleCreateAnalysis accepts an analysis result from the CLI and persists it.
+func (s *Server) handleCreateAnalysis(w http.ResponseWriter, r *http.Request) {
+	oc, ok := s.requireOrgMember(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Owner       string                 `json:"owner"`
+		Repo        string                 `json:"repo"`
+		RunID       int64                  `json:"run_id"`
+		Branch      string                 `json:"branch"`
+		CommitSHA   string                 `json:"commit_sha"`
+		Category    string                 `json:"category"`
+		Confidence  *int                   `json:"confidence"`
+		Sensitivity string                 `json:"sensitivity"`
+		RCA         *llm.RootCauseAnalysis `json:"rca"`
+		Text        string                 `json:"text"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Owner == "" || req.Repo == "" || req.RunID == 0 || req.Category == "" || req.Text == "" {
+		writeError(w, http.StatusBadRequest, "owner, repo, run_id, category, and text are required")
+		return
+	}
+
+	// Check usage limit
+	canAnalyze, err := s.usageChecker.CanAnalyze(r.Context(), oc.OrgID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check usage")
+		return
+	}
+	if !canAnalyze {
+		writeError(w, http.StatusTooManyRequests, "monthly analysis limit exceeded")
+		return
+	}
+
+	// Get or create repository
+	repo, err := s.db.GetOrCreateRepository(r.Context(), oc.OrgID, req.Owner, req.Repo)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve repository")
+		return
+	}
+
+	// Build params
+	params := database.CreateAnalysisParams{
+		RepoID:   repo.ID,
+		RunID:    req.RunID,
+		Category: req.Category,
+		Text:     req.Text,
+		RCA:      req.RCA,
+	}
+	if req.Branch != "" {
+		params.Branch = &req.Branch
+	}
+	if req.CommitSHA != "" {
+		params.CommitSHA = &req.CommitSHA
+	}
+	if req.Confidence != nil {
+		params.Confidence = req.Confidence
+	}
+	if req.Sensitivity != "" {
+		params.Sensitivity = &req.Sensitivity
+	}
+
+	analysis, err := s.db.CreateAnalysis(r.Context(), params)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique constraint") {
+			writeError(w, http.StatusConflict, "analysis for this run already exists")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to create analysis")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id": analysis.ID,
+	})
 }

--- a/internal/api/analysis_handlers.go
+++ b/internal/api/analysis_handlers.go
@@ -1,10 +1,11 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/kamilpajak/heisenberg/internal/database"
 	"github.com/kamilpajak/heisenberg/pkg/llm"
 )
@@ -194,7 +195,8 @@ func (s *Server) handleCreateAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	analysis, err := s.db.CreateAnalysis(r.Context(), params)
 	if err != nil {
-		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique constraint") {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 			writeError(w, http.StatusConflict, "analysis for this run already exists")
 			return
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -41,7 +41,8 @@ func NewServer(cfg Config) *Server {
 }
 
 func (s *Server) registerRoutes() {
-	authMiddleware := auth.Middleware(s.authVerifier)
+	apiKeyStore := &dbAPIKeyStore{db: s.db}
+	authMiddleware := auth.Middleware(s.authVerifier, apiKeyStore)
 
 	// Public endpoints
 	s.mux.HandleFunc("GET /health", s.handleHealth)
@@ -59,6 +60,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}/analyses", s.withAuth(authMiddleware, s.handleListAnalyses))
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/analyses/{analysisID}", s.withAuth(authMiddleware, s.handleGetAnalysis))
 	s.mux.HandleFunc("POST /api/organizations/{orgID}/analyses", s.withAuth(authMiddleware, s.handleCreateAnalysis))
+	s.mux.HandleFunc("POST /api/organizations/{orgID}/api-keys", s.withAuth(authMiddleware, s.handleCreateAPIKey))
+	s.mux.HandleFunc("GET /api/organizations/{orgID}/api-keys", s.withAuth(authMiddleware, s.handleListAPIKeys))
+	s.mux.HandleFunc("DELETE /api/organizations/{orgID}/api-keys/{keyID}", s.withAuth(authMiddleware, s.handleDeleteAPIKey))
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/usage", s.withAuth(authMiddleware, s.handleGetUsage))
 
 	// Billing endpoints

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -58,6 +58,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}", s.withAuth(authMiddleware, s.handleGetRepository))
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}/analyses", s.withAuth(authMiddleware, s.handleListAnalyses))
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/analyses/{analysisID}", s.withAuth(authMiddleware, s.handleGetAnalysis))
+	s.mux.HandleFunc("POST /api/organizations/{orgID}/analyses", s.withAuth(authMiddleware, s.handleCreateAnalysis))
 	s.mux.HandleFunc("GET /api/organizations/{orgID}/usage", s.withAuth(authMiddleware, s.handleGetUsage))
 
 	// Billing endpoints

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -56,6 +56,7 @@ func testServer(t *testing.T, db *database.DB) *Server {
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}", server.handleGetRepository)
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}/analyses", server.handleListAnalyses)
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/analyses/{analysisID}", server.handleGetAnalysis)
+	server.mux.HandleFunc("POST /api/organizations/{orgID}/analyses", server.handleCreateAnalysis)
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/usage", server.handleGetUsage)
 	server.mux.HandleFunc("POST /api/billing/checkout", server.handleCreateCheckout)
 	server.mux.HandleFunc("POST /api/billing/portal", server.handleCreatePortal)
@@ -433,6 +434,115 @@ func TestAnalyses(t *testing.T) {
 		server.mux.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+func TestCreateAnalysis(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	server := testServer(t, db)
+
+	// Setup
+	kindeUserID := "kp_" + uuid.New().String()[:8]
+	email := "create-analysis-" + uuid.New().String()[:8] + "@example.com"
+	user, err := db.CreateUser(ctx, kindeUserID, email)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteUser(ctx, user.ID) })
+
+	org, err := db.CreateOrganizationWithOwner(ctx, "Create Analysis Org", user.ID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteOrganization(ctx, org.ID) })
+
+	t.Run("creates analysis and repository", func(t *testing.T) {
+		body := bytes.NewBufferString(`{
+			"owner": "testowner",
+			"repo": "testrepo",
+			"run_id": 99001,
+			"branch": "main",
+			"commit_sha": "abc123",
+			"category": "diagnosis",
+			"confidence": 85,
+			"sensitivity": "medium",
+			"text": "Root cause analysis text"
+		}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/analyses", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp["id"])
+	})
+
+	t.Run("duplicate run_id returns conflict", func(t *testing.T) {
+		body := bytes.NewBufferString(`{
+			"owner": "testowner",
+			"repo": "testrepo",
+			"run_id": 99001,
+			"category": "diagnosis",
+			"text": "Duplicate"
+		}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/analyses", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusConflict, rec.Code)
+	})
+
+	t.Run("invalid request body", func(t *testing.T) {
+		body := bytes.NewBufferString(`not json`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/analyses", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("missing required fields", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"owner": "testowner"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/analyses", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("non-member forbidden", func(t *testing.T) {
+		otherUserID := "kp_" + uuid.New().String()[:8]
+		otherEmail := "other-" + uuid.New().String()[:8] + "@example.com"
+		_, err := db.CreateUser(ctx, otherUserID, otherEmail)
+		require.NoError(t, err)
+
+		body := bytes.NewBufferString(`{
+			"owner": "testowner",
+			"repo": "testrepo",
+			"run_id": 99002,
+			"category": "diagnosis",
+			"text": "Should fail"
+		}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/analyses", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, otherUserID, otherEmail)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -57,6 +57,9 @@ func testServer(t *testing.T, db *database.DB) *Server {
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}/analyses", server.handleListAnalyses)
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/analyses/{analysisID}", server.handleGetAnalysis)
 	server.mux.HandleFunc("POST /api/organizations/{orgID}/analyses", server.handleCreateAnalysis)
+	server.mux.HandleFunc("POST /api/organizations/{orgID}/api-keys", server.handleCreateAPIKey)
+	server.mux.HandleFunc("GET /api/organizations/{orgID}/api-keys", server.handleListAPIKeys)
+	server.mux.HandleFunc("DELETE /api/organizations/{orgID}/api-keys/{keyID}", server.handleDeleteAPIKey)
 	server.mux.HandleFunc("GET /api/organizations/{orgID}/usage", server.handleGetUsage)
 	server.mux.HandleFunc("POST /api/billing/checkout", server.handleCreateCheckout)
 	server.mux.HandleFunc("POST /api/billing/portal", server.handleCreatePortal)
@@ -1024,4 +1027,121 @@ func TestConfig_Fields(t *testing.T) {
 	assert.Nil(t, cfg.DB)
 	assert.Nil(t, cfg.AuthVerifier)
 	assert.Nil(t, cfg.BillingClient)
+}
+
+func TestAPIKeys(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	server := testServer(t, db)
+
+	// Setup
+	kindeUserID := "kp_" + uuid.New().String()[:8]
+	email := "apikeys-" + uuid.New().String()[:8] + "@example.com"
+	user, err := db.CreateUser(ctx, kindeUserID, email)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteUser(ctx, user.ID) })
+
+	org, err := db.CreateOrganizationWithOwner(ctx, "API Keys Test Org", user.ID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteOrganization(ctx, org.ID) })
+
+	var createdKeyID string
+
+	t.Run("create API key", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"name": "CI Key"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/api-keys", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp["id"])
+		assert.NotEmpty(t, resp["key"])
+		assert.Equal(t, "CI Key", resp["name"])
+
+		// Key should start with hsb_ prefix
+		key, ok := resp["key"].(string)
+		require.True(t, ok)
+		assert.True(t, len(key) > 4)
+		assert.Equal(t, "hsb_", key[:4])
+
+		createdKeyID, _ = resp["id"].(string)
+	})
+
+	t.Run("create API key - missing name", func(t *testing.T) {
+		body := bytes.NewBufferString(`{}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/api-keys", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("list API keys", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/organizations/"+org.ID.String()+"/api-keys", nil)
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]any
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		keys, ok := resp["keys"].([]any)
+		require.True(t, ok)
+		assert.Len(t, keys, 1)
+
+		// Listed keys should NOT contain the plaintext key
+		first := keys[0].(map[string]any)
+		assert.NotEmpty(t, first["id"])
+		assert.Equal(t, "CI Key", first["name"])
+		_, hasKey := first["key"]
+		assert.False(t, hasKey, "listed keys must not expose plaintext key")
+	})
+
+	t.Run("delete API key", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/api/organizations/"+org.ID.String()+"/api-keys/"+createdKeyID, nil)
+		req = withAuthContext(req, kindeUserID, email)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+
+		// Verify deleted
+		listReq := httptest.NewRequest(http.MethodGet, "/api/organizations/"+org.ID.String()+"/api-keys", nil)
+		listReq = withAuthContext(listReq, kindeUserID, email)
+		listRec := httptest.NewRecorder()
+		server.mux.ServeHTTP(listRec, listReq)
+
+		var resp map[string]any
+		_ = json.Unmarshal(listRec.Body.Bytes(), &resp)
+		keys := resp["keys"].([]any)
+		assert.Len(t, keys, 0)
+	})
+
+	t.Run("non-member forbidden", func(t *testing.T) {
+		otherUserID := "kp_" + uuid.New().String()[:8]
+		otherEmail := "other-ak-" + uuid.New().String()[:8] + "@example.com"
+		_, _ = db.CreateUser(ctx, otherUserID, otherEmail)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/organizations/"+org.ID.String()+"/api-keys", nil)
+		req = withAuthContext(req, otherUserID, otherEmail)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1144,4 +1144,40 @@ func TestAPIKeys(t *testing.T) {
 
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
+
+	t.Run("member cannot create API key", func(t *testing.T) {
+		memberUserID := "kp_" + uuid.New().String()[:8]
+		memberEmail := "member-ak-" + uuid.New().String()[:8] + "@example.com"
+		memberUser, err := db.CreateUser(ctx, memberUserID, memberEmail)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.DeleteUser(ctx, memberUser.ID) })
+		_ = db.AddOrgMember(ctx, org.ID, memberUser.ID, database.RoleMember)
+
+		body := bytes.NewBufferString(`{"name": "Member Key"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations/"+org.ID.String()+"/api-keys", body)
+		req.Header.Set("Content-Type", "application/json")
+		req = withAuthContext(req, memberUserID, memberEmail)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("member cannot delete API key", func(t *testing.T) {
+		memberUserID := "kp_" + uuid.New().String()[:8]
+		memberEmail := "member-del-" + uuid.New().String()[:8] + "@example.com"
+		memberUser, err := db.CreateUser(ctx, memberUserID, memberEmail)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.DeleteUser(ctx, memberUser.ID) })
+		_ = db.AddOrgMember(ctx, org.ID, memberUser.ID, database.RoleMember)
+
+		req := httptest.NewRequest(http.MethodDelete, "/api/organizations/"+org.ID.String()+"/api-keys/"+uuid.New().String(), nil)
+		req = withAuthContext(req, memberUserID, memberEmail)
+		rec := httptest.NewRecorder()
+
+		server.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
 }

--- a/internal/api/apikey_handlers.go
+++ b/internal/api/apikey_handlers.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/kamilpajak/heisenberg/internal/auth"
+)
+
+// handleCreateAPIKey generates a new API key for the organization.
+// The plaintext key is returned once and never stored.
+func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
+	oc, ok := s.requireOrgMember(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	// Generate random key with hsb_ prefix
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate key")
+		return
+	}
+	plainKey := "hsb_" + base64.RawURLEncoding.EncodeToString(randomBytes)
+	keyHash := auth.HashAPIKey(plainKey)
+
+	key, err := s.db.CreateAPIKey(r.Context(), keyHash, oc.User.ID, oc.OrgID, req.Name)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create API key")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id":   key.ID,
+		"name": key.Name,
+		"key":  plainKey, // Shown once, never stored
+	})
+}
+
+// handleListAPIKeys returns all API keys for the organization (without hashes).
+func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
+	oc, ok := s.requireOrgMember(w, r)
+	if !ok {
+		return
+	}
+
+	keys, err := s.db.ListOrgAPIKeys(r.Context(), oc.OrgID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list API keys")
+		return
+	}
+
+	// Return without key_hash
+	type keyResponse struct {
+		ID         uuid.UUID `json:"id"`
+		Name       string    `json:"name"`
+		CreatedAt  string    `json:"created_at"`
+		LastUsedAt *string   `json:"last_used_at,omitempty"`
+	}
+
+	result := make([]keyResponse, 0, len(keys))
+	for _, k := range keys {
+		kr := keyResponse{
+			ID:        k.ID,
+			Name:      k.Name,
+			CreatedAt: k.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		}
+		if k.LastUsedAt != nil {
+			formatted := k.LastUsedAt.Format("2006-01-02T15:04:05Z")
+			kr.LastUsedAt = &formatted
+		}
+		result = append(result, kr)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"keys": result})
+}
+
+// handleDeleteAPIKey revokes an API key.
+func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
+	_, ok := s.requireOrgMember(w, r)
+	if !ok {
+		return
+	}
+
+	keyID, err := uuid.Parse(r.PathValue("keyID"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid key ID")
+		return
+	}
+
+	if err := s.db.DeleteAPIKey(r.Context(), keyID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete API key")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/apikey_handlers.go
+++ b/internal/api/apikey_handlers.go
@@ -7,13 +7,18 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kamilpajak/heisenberg/internal/auth"
+	"github.com/kamilpajak/heisenberg/internal/database"
 )
 
-// handleCreateAPIKey generates a new API key for the organization.
+// handleCreateAPIKey generates a new API key for the organization. Requires admin or owner role.
 // The plaintext key is returned once and never stored.
 func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	oc, ok := s.requireOrgMember(w, r)
 	if !ok {
+		return
+	}
+	if oc.Member.Role != database.RoleOwner && oc.Member.Role != database.RoleAdmin {
+		writeError(w, http.StatusForbidden, "only owners and admins can manage API keys")
 		return
 	}
 
@@ -89,10 +94,14 @@ func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"keys": result})
 }
 
-// handleDeleteAPIKey revokes an API key.
+// handleDeleteAPIKey revokes an API key. Requires admin or owner role.
 func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
-	_, ok := s.requireOrgMember(w, r)
+	oc, ok := s.requireOrgMember(w, r)
 	if !ok {
+		return
+	}
+	if oc.Member.Role != database.RoleOwner && oc.Member.Role != database.RoleAdmin {
+		writeError(w, http.StatusForbidden, "only owners and admins can manage API keys")
 		return
 	}
 
@@ -102,7 +111,7 @@ func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.db.DeleteAPIKey(r.Context(), keyID); err != nil {
+	if err := s.db.DeleteAPIKey(r.Context(), keyID, oc.OrgID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete API key")
 		return
 	}

--- a/internal/api/apikey_store.go
+++ b/internal/api/apikey_store.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kamilpajak/heisenberg/internal/auth"
+	"github.com/kamilpajak/heisenberg/internal/database"
+)
+
+// dbAPIKeyStore adapts *database.DB to auth.APIKeyStore.
+type dbAPIKeyStore struct {
+	db *database.DB
+}
+
+func (s *dbAPIKeyStore) GetAPIKeyByHash(ctx context.Context, keyHash string) (auth.APIKeyInfo, error) {
+	key, err := s.db.GetAPIKeyByHash(ctx, keyHash)
+	if err != nil {
+		return auth.APIKeyInfo{}, err
+	}
+	if key == nil {
+		return auth.APIKeyInfo{}, fmt.Errorf("API key not found")
+	}
+
+	// Look up user to get their ClerkID for context compatibility
+	user, err := s.db.GetUserByID(ctx, key.UserID)
+	if err != nil || user == nil {
+		return auth.APIKeyInfo{}, fmt.Errorf("API key owner not found")
+	}
+
+	return auth.APIKeyInfo{
+		ID:      key.ID,
+		UserID:  key.UserID,
+		OrgID:   key.OrgID,
+		ClerkID: user.ClerkID,
+	}, nil
+}
+
+func (s *dbAPIKeyStore) UpdateAPIKeyLastUsed(ctx context.Context, id uuid.UUID) error {
+	return s.db.UpdateAPIKeyLastUsed(ctx, id)
+}

--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -87,8 +87,7 @@ func TestE2E_CLIPersistence(t *testing.T) {
 	ts := e2eServer(t, db)
 
 	// Create SaaS client (same as CLI would use)
-	client := &saas.Client{}
-	*client = *mustNewTestClient(ts.URL, apiKey)
+	client := mustNewTestClient(ts.URL, apiKey)
 
 	// Submit analysis (simulating CLI after analysis.Run())
 	confidence := 85

--- a/internal/api/e2e_test.go
+++ b/internal/api/e2e_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kamilpajak/heisenberg/internal/auth"
+	"github.com/kamilpajak/heisenberg/internal/billing"
+	"github.com/kamilpajak/heisenberg/internal/database"
+	"github.com/kamilpajak/heisenberg/internal/testutil"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+	"github.com/kamilpajak/heisenberg/pkg/saas"
+
+	"github.com/google/uuid"
+)
+
+// seedTestAPIKey creates a user, org, and API key, returning the plaintext key.
+func seedTestAPIKey(t *testing.T, db *database.DB) (plainKey string, orgID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	clerkID := "kp_e2e_" + uuid.New().String()[:8]
+	email := "e2e-" + uuid.New().String()[:8] + "@example.com"
+
+	user, err := db.CreateUser(ctx, clerkID, email)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteUser(ctx, user.ID) })
+
+	org, err := db.CreateOrganizationWithOwner(ctx, "E2E Test Org", user.ID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteOrganization(ctx, org.ID) })
+
+	// Generate API key and store hash
+	plainKey = "hsb_e2etest_" + uuid.New().String()[:16]
+	keyHash := auth.HashAPIKey(plainKey)
+	_, err = db.CreateAPIKey(ctx, keyHash, user.ID, org.ID, "E2E Test Key")
+	require.NoError(t, err)
+
+	return plainKey, org.ID
+}
+
+// e2eServer creates an API server with real auth middleware (API key path).
+func e2eServer(t *testing.T, db *database.DB) *httptest.Server {
+	t.Helper()
+
+	billingClient := billing.NewClient(billing.Config{
+		SecretKey: "sk_test_fake",
+		PriceIDs: billing.PriceIDs{
+			Team:       "price_team_test",
+			Enterprise: "price_ent_test",
+		},
+	})
+
+	apiKeyStore := &dbAPIKeyStore{db: db}
+	server := &Server{
+		db:            db,
+		authVerifier:  nil, // No Kinde in tests
+		billingClient: billingClient,
+		usageChecker:  billing.NewUsageChecker(db),
+		mux:           http.NewServeMux(),
+	}
+
+	// Register routes WITH API key auth middleware (real auth path)
+	authMiddleware := auth.Middleware(nil, apiKeyStore)
+	server.mux.HandleFunc("GET /health", server.handleHealth)
+	server.mux.HandleFunc("POST /api/organizations/{orgID}/analyses", server.withAuth(authMiddleware, server.handleCreateAnalysis))
+	server.mux.HandleFunc("GET /api/organizations/{orgID}/repositories/{repoID}/analyses", server.withAuth(authMiddleware, server.handleListAnalyses))
+
+	ts := httptest.NewServer(server)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestE2E_CLIPersistence(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	// Seed API key (real hash in DB)
+	apiKey, orgID := seedTestAPIKey(t, db)
+
+	// Start real HTTP server with API key auth
+	ts := e2eServer(t, db)
+
+	// Create SaaS client (same as CLI would use)
+	client := &saas.Client{}
+	*client = *mustNewTestClient(ts.URL, apiKey)
+
+	// Submit analysis (simulating CLI after analysis.Run())
+	confidence := 85
+	id, err := client.SubmitAnalysis(ctx, saas.SubmitParams{
+		OrgID:     orgID.String(),
+		Owner:     "e2eowner",
+		Repo:      "e2erepo",
+		RunID:     77001,
+		Branch:    "main",
+		CommitSHA: "e2eabc123",
+		Result: &llm.AnalysisResult{
+			Text:        "E2E root cause: timeout in checkout flow",
+			Category:    llm.CategoryDiagnosis,
+			Confidence:  confidence,
+			Sensitivity: "medium",
+			RCA: &llm.RootCauseAnalysis{
+				Title:       "Checkout timeout",
+				FailureType: llm.FailureTypeTimeout,
+				RootCause:   "Modal overlay blocks submit button",
+				Remediation: "Wait for modal to close before clicking submit",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, id)
+
+	// Verify: analysis persisted in DB
+	analysisID, err := uuid.Parse(id)
+	require.NoError(t, err)
+	analysis, err := db.GetAnalysisByID(ctx, analysisID)
+	require.NoError(t, err)
+	assert.Equal(t, "E2E root cause: timeout in checkout flow", analysis.Text)
+	assert.Equal(t, llm.CategoryDiagnosis, analysis.Category)
+	assert.Equal(t, &confidence, analysis.Confidence)
+	assert.NotNil(t, analysis.RCA)
+	assert.Equal(t, "Checkout timeout", analysis.RCA.Title)
+	assert.Equal(t, "main", *analysis.Branch)
+	assert.Equal(t, "e2eabc123", *analysis.CommitSHA)
+}
+
+func TestE2E_DuplicateRunID(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	apiKey, orgID := seedTestAPIKey(t, db)
+	ts := e2eServer(t, db)
+	client := mustNewTestClient(ts.URL, apiKey)
+
+	params := saas.SubmitParams{
+		OrgID: orgID.String(),
+		Owner: "dupeowner", Repo: "duperepo",
+		RunID:  77002,
+		Result: &llm.AnalysisResult{Text: "First", Category: llm.CategoryDiagnosis},
+	}
+
+	// First submit: success
+	_, err := client.SubmitAnalysis(ctx, params)
+	require.NoError(t, err)
+
+	// Second submit: conflict
+	_, err = client.SubmitAnalysis(ctx, params)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "409")
+}
+
+func TestE2E_InvalidAPIKey(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	_, orgID := seedTestAPIKey(t, db)
+	ts := e2eServer(t, db)
+	client := mustNewTestClient(ts.URL, "hsb_invalid_key_does_not_exist")
+
+	_, err := client.SubmitAnalysis(ctx, saas.SubmitParams{
+		OrgID: orgID.String(),
+		Owner: "badowner", Repo: "badrepo",
+		RunID:  77003,
+		Result: &llm.AnalysisResult{Text: "Should fail", Category: "diagnosis"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+// mustNewTestClient creates a saas.Client for testing without env vars.
+func mustNewTestClient(baseURL, apiKey string) *saas.Client {
+	return saas.NewTestClient(baseURL, apiKey)
+}

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const apiKeyPrefix = "hsb_"
+
+// APIKeyInfo contains the resolved identity from an API key lookup.
+type APIKeyInfo struct {
+	ID      uuid.UUID
+	UserID  uuid.UUID
+	OrgID   uuid.UUID
+	ClerkID string // User's external auth ID (for context compatibility)
+}
+
+// APIKeyStore looks up API keys by their hash.
+type APIKeyStore interface {
+	GetAPIKeyByHash(ctx context.Context, keyHash string) (APIKeyInfo, error)
+	UpdateAPIKeyLastUsed(ctx context.Context, id uuid.UUID) error
+}
+
+// IsAPIKey returns true if the token has the API key prefix.
+func IsAPIKey(token string) bool {
+	return strings.HasPrefix(token, apiKeyPrefix)
+}
+
+// HashAPIKey returns the SHA-256 hex digest of an API key.
+func HashAPIKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/auth/kinde.go
+++ b/internal/auth/kinde.go
@@ -97,8 +97,14 @@ func (v *Verifier) Verify(tokenString string) (*KindeClaims, error) {
 	return claims, nil
 }
 
-// Middleware creates HTTP middleware that verifies Kinde JWTs.
-func Middleware(verifier *Verifier) func(http.Handler) http.Handler {
+// Middleware creates HTTP middleware that verifies Kinde JWTs and API keys.
+// If apiKeyStore is non-nil, tokens prefixed with "hsb_" are authenticated as API keys.
+func Middleware(verifier *Verifier, apiKeyStore ...APIKeyStore) func(http.Handler) http.Handler {
+	var store APIKeyStore
+	if len(apiKeyStore) > 0 {
+		store = apiKeyStore[0]
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractBearerToken(r)
@@ -107,13 +113,35 @@ func Middleware(verifier *Verifier) func(http.Handler) http.Handler {
 				return
 			}
 
+			// API key authentication
+			if IsAPIKey(token) && store != nil {
+				keyHash := HashAPIKey(token)
+				info, err := store.GetAPIKeyByHash(r.Context(), keyHash)
+				if err != nil {
+					http.Error(w, "Unauthorized: invalid API key", http.StatusUnauthorized)
+					return
+				}
+
+				// Update last used (fire-and-forget)
+				go func() { _ = store.UpdateAPIKeyLastUsed(context.Background(), info.ID) }()
+
+				claims := &KindeClaims{
+					RegisteredClaims: jwt.RegisteredClaims{
+						Subject: info.ClerkID,
+					},
+				}
+				ctx := context.WithValue(r.Context(), claimsKey, claims)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			// Kinde JWT authentication
 			claims, err := verifier.Verify(token)
 			if err != nil {
 				http.Error(w, "Unauthorized: invalid token", http.StatusUnauthorized)
 				return
 			}
 
-			// Attach claims to context
 			ctx := context.WithValue(r.Context(), claimsKey, claims)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/internal/auth/kinde_test.go
+++ b/internal/auth/kinde_test.go
@@ -2,11 +2,13 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -245,6 +247,106 @@ func TestMiddleware_InvalidToken_PanicsWithNilJWKS(t *testing.T) {
 	// Verifier with nil JWKS will panic - this is expected behavior
 	// In production, NewVerifier always initializes JWKS
 	t.Skip("Requires mock JWKS server - covered by integration tests")
+}
+
+func TestIsAPIKey(t *testing.T) {
+	assert.True(t, IsAPIKey("hsb_abc123"))
+	assert.False(t, IsAPIKey("eyJhbGciOiJSUzI1NiJ9.jwt"))
+	assert.False(t, IsAPIKey(""))
+	assert.False(t, IsAPIKey("hsb"))
+}
+
+func TestHashAPIKey(t *testing.T) {
+	hash := HashAPIKey("hsb_testkey123")
+	assert.Len(t, hash, 64) // SHA-256 hex = 64 chars
+	// Same input → same output
+	assert.Equal(t, hash, HashAPIKey("hsb_testkey123"))
+	// Different input → different output
+	assert.NotEqual(t, hash, HashAPIKey("hsb_otherkey"))
+}
+
+type mockAPIKeyStore struct {
+	getByHash  func(ctx context.Context, keyHash string) (APIKeyInfo, error)
+	updateUsed func(ctx context.Context, id uuid.UUID) error
+}
+
+func (m *mockAPIKeyStore) GetAPIKeyByHash(ctx context.Context, keyHash string) (APIKeyInfo, error) {
+	return m.getByHash(ctx, keyHash)
+}
+func (m *mockAPIKeyStore) UpdateAPIKeyLastUsed(ctx context.Context, id uuid.UUID) error {
+	if m.updateUsed != nil {
+		return m.updateUsed(ctx, id)
+	}
+	return nil
+}
+
+func TestMiddleware_APIKey_Valid(t *testing.T) {
+	testKeyID := uuid.New()
+	store := &mockAPIKeyStore{
+		getByHash: func(ctx context.Context, keyHash string) (APIKeyInfo, error) {
+			return APIKeyInfo{
+				ID:      testKeyID,
+				UserID:  uuid.New(),
+				OrgID:   uuid.New(),
+				ClerkID: "kp_testuser",
+			}, nil
+		},
+	}
+
+	var capturedUserID string
+	handler := Middleware(nil, store)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUserID = UserID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer hsb_testkey123")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "kp_testuser", capturedUserID)
+}
+
+func TestMiddleware_APIKey_Invalid(t *testing.T) {
+	store := &mockAPIKeyStore{
+		getByHash: func(ctx context.Context, keyHash string) (APIKeyInfo, error) {
+			return APIKeyInfo{}, fmt.Errorf("not found")
+		},
+	}
+
+	handler := Middleware(nil, store)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer hsb_invalidkey")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestMiddleware_APIKey_NoStore(t *testing.T) {
+	// API key token without store configured → falls through to JWT (panics with nil verifier)
+	handler := Middleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer hsb_nostore")
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		if r := recover(); r != nil {
+			// Expected: no store, falls to JWT path, nil verifier panics
+			assert.NotNil(t, r)
+		}
+	}()
+
+	handler.ServeHTTP(rec, req)
 }
 
 func TestOptionalMiddleware_InvalidToken_PanicsWithNilJWKS(t *testing.T) {

--- a/internal/database/api_keys.go
+++ b/internal/database/api_keys.go
@@ -1,0 +1,87 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// APIKey represents a stored API key (hash only, never plaintext).
+type APIKey struct {
+	ID         uuid.UUID
+	KeyHash    string
+	UserID     uuid.UUID
+	OrgID      uuid.UUID
+	Name       string
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
+}
+
+// CreateAPIKey stores a new API key hash.
+func (db *DB) CreateAPIKey(ctx context.Context, keyHash string, userID, orgID uuid.UUID, name string) (*APIKey, error) {
+	var key APIKey
+	err := db.pool.QueryRow(ctx,
+		`INSERT INTO api_keys (key_hash, user_id, org_id, name)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING id, key_hash, user_id, org_id, name, created_at, last_used_at`,
+		keyHash, userID, orgID, name,
+	).Scan(&key.ID, &key.KeyHash, &key.UserID, &key.OrgID, &key.Name, &key.CreatedAt, &key.LastUsedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &key, nil
+}
+
+// GetAPIKeyByHash retrieves an API key by its hash.
+func (db *DB) GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error) {
+	var key APIKey
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, key_hash, user_id, org_id, name, created_at, last_used_at
+		 FROM api_keys WHERE key_hash = $1`,
+		keyHash,
+	).Scan(&key.ID, &key.KeyHash, &key.UserID, &key.OrgID, &key.Name, &key.CreatedAt, &key.LastUsedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &key, nil
+}
+
+// UpdateAPIKeyLastUsed updates the last_used_at timestamp.
+func (db *DB) UpdateAPIKeyLastUsed(ctx context.Context, id uuid.UUID) error {
+	_, err := db.pool.Exec(ctx,
+		`UPDATE api_keys SET last_used_at = NOW() WHERE id = $1`, id)
+	return err
+}
+
+// ListOrgAPIKeys returns all API keys for an organization.
+func (db *DB) ListOrgAPIKeys(ctx context.Context, orgID uuid.UUID) ([]APIKey, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT id, key_hash, user_id, org_id, name, created_at, last_used_at
+		 FROM api_keys WHERE org_id = $1 ORDER BY created_at DESC`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []APIKey
+	for rows.Next() {
+		var key APIKey
+		if err := rows.Scan(&key.ID, &key.KeyHash, &key.UserID, &key.OrgID, &key.Name, &key.CreatedAt, &key.LastUsedAt); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+// DeleteAPIKey removes an API key.
+func (db *DB) DeleteAPIKey(ctx context.Context, id uuid.UUID) error {
+	_, err := db.pool.Exec(ctx, `DELETE FROM api_keys WHERE id = $1`, id)
+	return err
+}

--- a/internal/database/api_keys.go
+++ b/internal/database/api_keys.go
@@ -80,8 +80,8 @@ func (db *DB) ListOrgAPIKeys(ctx context.Context, orgID uuid.UUID) ([]APIKey, er
 	return keys, rows.Err()
 }
 
-// DeleteAPIKey removes an API key.
-func (db *DB) DeleteAPIKey(ctx context.Context, id uuid.UUID) error {
-	_, err := db.pool.Exec(ctx, `DELETE FROM api_keys WHERE id = $1`, id)
+// DeleteAPIKey removes an API key, scoped to the organization for safety.
+func (db *DB) DeleteAPIKey(ctx context.Context, id, orgID uuid.UUID) error {
+	_, err := db.pool.Exec(ctx, `DELETE FROM api_keys WHERE id = $1 AND org_id = $2`, id, orgID)
 	return err
 }

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -598,7 +598,7 @@ func TestAPIKeyCRUD(t *testing.T) {
 	assert.Len(t, keys, 1)
 
 	// Delete
-	err = db.DeleteAPIKey(ctx, key.ID)
+	err = db.DeleteAPIKey(ctx, key.ID, org.ID)
 	require.NoError(t, err)
 	deleted, _ := db.GetAPIKeyByHash(ctx, keyHash)
 	assert.Nil(t, deleted)

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -549,3 +549,57 @@ func TestAddOrgMemberUpsert(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, database.RoleAdmin, member.Role)
 }
+
+func TestAPIKeyCRUD(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+
+	// Setup
+	clerkID := "clerk_" + uuid.New().String()[:8]
+	user, err := db.CreateUser(ctx, clerkID, "apikey@example.com")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteUser(ctx, user.ID) })
+
+	org, err := db.CreateOrganizationWithOwner(ctx, "API Key Test Org", user.ID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.DeleteOrganization(ctx, org.ID) })
+
+	keyHash := "sha256_" + uuid.New().String()
+
+	// Create
+	key, err := db.CreateAPIKey(ctx, keyHash, user.ID, org.ID, "Test Key")
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, key.ID)
+	assert.Equal(t, keyHash, key.KeyHash)
+	assert.Equal(t, "Test Key", key.Name)
+	assert.Nil(t, key.LastUsedAt)
+
+	// Get by hash
+	found, err := db.GetAPIKeyByHash(ctx, keyHash)
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, found.ID)
+	assert.Equal(t, user.ID, found.UserID)
+	assert.Equal(t, org.ID, found.OrgID)
+
+	// Get by hash — not found
+	notFound, err := db.GetAPIKeyByHash(ctx, "nonexistent_hash")
+	require.NoError(t, err)
+	assert.Nil(t, notFound)
+
+	// Update last used
+	err = db.UpdateAPIKeyLastUsed(ctx, key.ID)
+	require.NoError(t, err)
+	updated, _ := db.GetAPIKeyByHash(ctx, keyHash)
+	assert.NotNil(t, updated.LastUsedAt)
+
+	// List
+	keys, err := db.ListOrgAPIKeys(ctx, org.ID)
+	require.NoError(t, err)
+	assert.Len(t, keys, 1)
+
+	// Delete
+	err = db.DeleteAPIKey(ctx, key.ID)
+	require.NoError(t, err)
+	deleted, _ := db.GetAPIKeyByHash(ctx, keyHash)
+	assert.Nil(t, deleted)
+}

--- a/internal/database/migrations/002_api_keys.down.sql
+++ b/internal/database/migrations/002_api_keys.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS api_keys;

--- a/internal/database/migrations/002_api_keys.up.sql
+++ b/internal/database/migrations/002_api_keys.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE api_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key_hash TEXT NOT NULL UNIQUE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_api_keys_org_id ON api_keys(org_id);

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -90,7 +90,16 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		return nil, err
 	}
 
-	return llmClient.RunAgentLoop(ctx, handler, ToolDeclarations(), initialContext, p.Verbose)
+	result, err := llmClient.RunAgentLoop(ctx, handler, ToolDeclarations(), initialContext, p.Verbose)
+	if err != nil {
+		return nil, err
+	}
+
+	result.RunID = resolvedRunID
+	result.Branch = wfRun.HeadBranch
+	result.CommitSHA = wfRun.HeadSHA
+
+	return result, nil
 }
 
 func emitInfo(e llm.ProgressEmitter, msg string) {

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -109,10 +109,13 @@ type ToolExecutor interface {
 // AnalysisResult holds the final output from the agent loop.
 type AnalysisResult struct {
 	Text        string             `json:"text"`
-	Category    string             `json:"category"`      // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
-	Confidence  int                `json:"confidence"`    // 0-100, meaningful only for "diagnosis"
-	Sensitivity string             `json:"sensitivity"`   // "high", "medium", "low", meaningful only for "diagnosis"
-	RCA         *RootCauseAnalysis `json:"rca,omitempty"` // Structured diagnosis, only for "diagnosis"
+	Category    string             `json:"category"`             // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
+	Confidence  int                `json:"confidence"`           // 0-100, meaningful only for "diagnosis"
+	Sensitivity string             `json:"sensitivity"`          // "high", "medium", "low", meaningful only for "diagnosis"
+	RCA         *RootCauseAnalysis `json:"rca,omitempty"`        // Structured diagnosis, only for "diagnosis"
+	RunID       int64              `json:"run_id,omitempty"`     // GitHub workflow run ID
+	Branch      string             `json:"branch,omitempty"`     // Git branch name
+	CommitSHA   string             `json:"commit_sha,omitempty"` // Git commit SHA
 }
 
 // GenerationConfig controls response generation.

--- a/pkg/saas/client.go
+++ b/pkg/saas/client.go
@@ -35,6 +35,15 @@ func NewClient() *Client {
 	}
 }
 
+// NewTestClient creates a client with explicit URL and key (for testing).
+func NewTestClient(baseURL, apiKey string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
 // BaseURL returns the configured API base URL.
 func (c *Client) BaseURL() string {
 	return c.baseURL

--- a/pkg/saas/client.go
+++ b/pkg/saas/client.go
@@ -1,0 +1,111 @@
+// Package saas provides an HTTP client for the Heisenberg SaaS API.
+package saas
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+)
+
+// Client sends analysis results to the Heisenberg SaaS API.
+type Client struct {
+	baseURL string
+	apiKey  string
+	http    *http.Client
+}
+
+// NewClient creates a SaaS client from environment variables.
+// Returns nil if HEISENBERG_API_URL or HEISENBERG_API_KEY is not set.
+func NewClient() *Client {
+	url := os.Getenv("HEISENBERG_API_URL")
+	key := os.Getenv("HEISENBERG_API_KEY")
+	if url == "" || key == "" {
+		return nil
+	}
+	return &Client{
+		baseURL: url,
+		apiKey:  key,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// BaseURL returns the configured API base URL.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
+// SubmitParams holds the data needed to persist an analysis.
+type SubmitParams struct {
+	OrgID     string
+	Owner     string
+	Repo      string
+	RunID     int64
+	Branch    string
+	CommitSHA string
+	Result    *llm.AnalysisResult
+}
+
+// SubmitAnalysis sends an analysis result to the SaaS API for persistence.
+// Returns the analysis ID on success.
+func (c *Client) SubmitAnalysis(ctx context.Context, p SubmitParams) (string, error) {
+	body := map[string]any{
+		"owner":    p.Owner,
+		"repo":     p.Repo,
+		"run_id":   p.RunID,
+		"category": p.Result.Category,
+		"text":     p.Result.Text,
+	}
+	if p.Branch != "" {
+		body["branch"] = p.Branch
+	}
+	if p.CommitSHA != "" {
+		body["commit_sha"] = p.CommitSHA
+	}
+	if p.Result.Confidence > 0 {
+		body["confidence"] = p.Result.Confidence
+	}
+	if p.Result.Sensitivity != "" {
+		body["sensitivity"] = p.Result.Sensitivity
+	}
+	if p.Result.RCA != nil {
+		body["rca"] = p.Result.RCA
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/organizations/%s/analyses", c.baseURL, p.OrgID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to submit analysis: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("API returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.ID, nil
+}

--- a/pkg/saas/client_test.go
+++ b/pkg/saas/client_test.go
@@ -1,0 +1,99 @@
+package saas
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient_ReturnsNilWhenNotConfigured(t *testing.T) {
+	t.Setenv("HEISENBERG_API_URL", "")
+	t.Setenv("HEISENBERG_API_KEY", "")
+	c := NewClient()
+	assert.Nil(t, c)
+}
+
+func TestNewClient_ReturnsClientWhenConfigured(t *testing.T) {
+	t.Setenv("HEISENBERG_API_URL", "https://api.heisenberg.dev")
+	t.Setenv("HEISENBERG_API_KEY", "hb_test_key")
+	c := NewClient()
+	assert.NotNil(t, c)
+	assert.Equal(t, "https://api.heisenberg.dev", c.BaseURL())
+}
+
+func TestSubmitAnalysis_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/organizations/org-123/analyses", r.URL.Path)
+		assert.Equal(t, "Bearer hb_test_key", r.Header.Get("Authorization"))
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Equal(t, "testowner", body["owner"])
+		assert.Equal(t, "testrepo", body["repo"])
+		assert.Equal(t, float64(12345), body["run_id"])
+
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "analysis-uuid-123"})
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, apiKey: "hb_test_key", http: http.DefaultClient}
+	id, err := c.SubmitAnalysis(context.Background(), SubmitParams{
+		OrgID: "org-123",
+		Owner: "testowner",
+		Repo:  "testrepo",
+		RunID: 12345,
+		Result: &llm.AnalysisResult{
+			Text:     "Analysis text",
+			Category: llm.CategoryDiagnosis,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "analysis-uuid-123", id)
+}
+
+func TestSubmitAnalysis_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, apiKey: "bad_key", http: http.DefaultClient}
+	_, err := c.SubmitAnalysis(context.Background(), SubmitParams{
+		OrgID:  "org-123",
+		Owner:  "testowner",
+		Repo:   "testrepo",
+		RunID:  12345,
+		Result: &llm.AnalysisResult{Text: "x", Category: "diagnosis"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestSubmitAnalysis_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "already exists"})
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, apiKey: "key", http: http.DefaultClient}
+	_, err := c.SubmitAnalysis(context.Background(), SubmitParams{
+		OrgID:  "org-123",
+		Owner:  "testowner",
+		Repo:   "testrepo",
+		RunID:  12345,
+		Result: &llm.AnalysisResult{Text: "x", Category: "diagnosis"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "409")
+}


### PR DESCRIPTION
## Summary

Phase 3a: CLI→API→DB persistence with API key authentication.

- Extend `AnalysisResult` with `RunID`, `Branch`, `CommitSHA` metadata
- Add `POST /api/organizations/{orgID}/analyses` endpoint with usage limit enforcement
- Add `pkg/saas` HTTP client (Apache 2.0) for CLI-to-API communication
- Integrate persistence in CLI — submits results when `HEISENBERG_API_URL` is configured
- Add API key authentication (`hsb_` prefixed, SHA-256 hashed) alongside Kinde JWT
- Add API key management endpoints (create/list/delete)
- Add E2E tests verifying full CLI→API key auth→DB persistence flow

## Architecture

```
CLI (Apache 2.0)
  → Authorization: Bearer hsb_<key>
  → POST /api/organizations/{orgID}/analyses
  → Auth middleware: hsb_ prefix → DB hash lookup → inject claims
  → db.GetOrCreateRepository + db.CreateAnalysis
  → PostgreSQL
```

License boundary preserved: CLI uses only `pkg/saas` (Apache 2.0), never imports `internal/` (BSL).

## Configuration

| Variable | Purpose | Required |
|----------|---------|----------|
| `HEISENBERG_API_URL` | SaaS API base URL | No — without it, CLI works local-only |
| `HEISENBERG_API_KEY` | API key (generated in dashboard) | No — same |
| `HEISENBERG_ORG_ID` | Organization ID | No — same |

## Test plan

- [x] API endpoint: create, duplicate (409), invalid body, missing fields, non-member (403)
- [x] SaaS client: success, unauthorized (401), conflict (409), nil when unconfigured
- [x] API keys: CRUD in DB, create/list/delete endpoints, non-member forbidden
- [x] Auth middleware: valid API key, invalid API key, no store configured
- [x] E2E: full CLI→API key→DB flow, duplicate run, invalid key
- [x] Full suite: `go test -race ./...` (14 packages, 0 failures)
- [ ] CI pipeline passes