### PR TITLE
fix: add agent loop guardrails for large repos (#19)

### DIFF
--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -83,6 +83,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		RunID:        resolvedRunID,
 		SnapshotHTML: p.SnapshotHTML,
 		Emitter:      p.Emitter,
+		artifacts:    artifacts, // pre-populate so HasTestArtifacts() works immediately
 	}
 
 	llmClient, err := llm.NewClient()
@@ -132,20 +133,35 @@ func buildInitialContext(run *gh.WorkflowRun, jobs []gh.Job, artifacts []gh.Arti
 	if len(artifacts) == 0 {
 		b.WriteString("No artifacts found.\n")
 	}
+	hasTestArtifacts := false
 	for _, a := range artifacts {
 		expired := ""
 		if a.Expired {
 			expired = " [EXPIRED]"
 		}
-		fmt.Fprintf(&b, "- %s (%d bytes)%s\n", a.Name, a.SizeBytes, expired)
+		label := ""
+		if !a.Expired && isTestArtifact(a.Name) {
+			label = " [TEST REPORT]"
+			hasTestArtifacts = true
+		}
+		fmt.Fprintf(&b, "- %s (%d bytes)%s%s\n", a.Name, a.SizeBytes, label, expired)
 	}
 
 	b.WriteString("\n## Instructions\n")
 	b.WriteString("Analyze this workflow run to determine why it failed.\n")
-	b.WriteString("Use the available tools to fetch artifacts, logs, and source files as needed.\n")
+	if hasTestArtifacts {
+		b.WriteString("IMPORTANT: Test report artifacts are available. Start by fetching them using get_artifact to understand which tests failed and why. Only read source files after analyzing test reports.\n")
+	}
 	b.WriteString("When you have enough information, you MUST call the 'done' tool first, then provide your final root cause analysis.\n")
 
 	return b.String()
+}
+
+// isTestArtifact returns true if the artifact name suggests it contains test results.
+func isTestArtifact(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "report") || strings.Contains(lower, "test-results") ||
+		strings.Contains(lower, "blob")
 }
 
 // findRunToAnalyze determines which run to analyze based on smart selection logic.

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -5,6 +5,7 @@ import (
 
 	gh "github.com/kamilpajak/heisenberg/pkg/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatRunDate_ValidRFC3339(t *testing.T) {
@@ -90,4 +91,47 @@ func TestFindRunToAnalyze_LatestIsCancelled(t *testing.T) {
 
 	assert.False(t, skip, "should analyze failure even if latest is cancelled")
 	assert.Equal(t, int64(2), runID)
+}
+
+func TestBuildInitialContext_WithTestArtifacts(t *testing.T) {
+	run := &gh.WorkflowRun{ID: 123, Name: "CI", Conclusion: "failure"}
+	jobs := []gh.Job{{Name: "test", ID: 1, Status: "completed", Conclusion: "failure"}}
+	artifacts := []gh.Artifact{
+		{Name: "playwright-report", SizeBytes: 45000, Expired: false},
+		{Name: "build-cache", SizeBytes: 500000, Expired: false},
+	}
+
+	ctx := buildInitialContext(run, jobs, artifacts)
+
+	// Should classify test artifacts
+	assert.Contains(t, ctx, "TEST REPORT")
+	// Should have prioritized instruction
+	assert.Contains(t, ctx, "IMPORTANT")
+	assert.Contains(t, ctx, "get_artifact")
+	// Build cache should not be labeled as test report
+	require.NotContains(t, ctx, "build-cache (500000 bytes) [TEST REPORT]")
+}
+
+func TestBuildInitialContext_WithoutTestArtifacts(t *testing.T) {
+	run := &gh.WorkflowRun{ID: 123, Name: "CI", Conclusion: "failure"}
+	jobs := []gh.Job{{Name: "build", ID: 1, Status: "completed", Conclusion: "failure"}}
+	artifacts := []gh.Artifact{
+		{Name: "build-output", SizeBytes: 100000, Expired: false},
+	}
+
+	ctx := buildInitialContext(run, jobs, artifacts)
+
+	assert.NotContains(t, ctx, "IMPORTANT")
+	assert.NotContains(t, ctx, "TEST REPORT")
+}
+
+func TestBuildInitialContext_NoArtifacts(t *testing.T) {
+	run := &gh.WorkflowRun{ID: 123, Name: "CI", Conclusion: "failure"}
+	jobs := []gh.Job{}
+	artifacts := []gh.Artifact{}
+
+	ctx := buildInitialContext(run, jobs, artifacts)
+
+	assert.Contains(t, ctx, "No artifacts found")
+	assert.NotContains(t, ctx, "IMPORTANT")
 }

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -20,12 +20,13 @@ type ToolHandler struct {
 	SnapshotHTML func([]byte) ([]byte, error)
 	Emitter      llm.ProgressEmitter
 
-	artifacts    []gh.Artifact          // cached after first list
-	calledTraces bool                   // whether get_test_traces has been called
-	category     string                 // set by done tool
-	confidence   int                    // 0-100, set by done tool
-	sensitivity  string                 // "high", "medium", "low", set by done tool
-	rca          *llm.RootCauseAnalysis // structured RCA, set by done tool
+	artifacts           []gh.Artifact          // cached after first list
+	calledTraces        bool                   // whether get_test_traces has been called
+	hasReadErrorContext bool                   // set after fetching logs/artifacts/traces
+	category            string                 // set by done tool
+	confidence          int                    // 0-100, set by done tool
+	sensitivity         string                 // "high", "medium", "low", set by done tool
+	rca                 *llm.RootCauseAnalysis // structured RCA, set by done tool
 }
 
 // Execute dispatches a function call, returning the result string and whether
@@ -90,6 +91,8 @@ func (h *ToolHandler) listJobs(ctx context.Context) (string, bool, error) {
 }
 
 func (h *ToolHandler) getJobLogs(ctx context.Context, args map[string]any) (string, bool, error) {
+	h.hasReadErrorContext = true
+
 	jobID, err := intArg(args, "job_id")
 	if err != nil {
 		return errorResult(err), false, nil
@@ -131,6 +134,8 @@ func (h *ToolHandler) findArtifactByName(name string) *gh.Artifact {
 }
 
 func (h *ToolHandler) getArtifact(ctx context.Context, args map[string]any) (string, bool, error) {
+	h.hasReadErrorContext = true
+
 	name, _ := args["artifact_name"].(string)
 	if name == "" {
 		return errorResult(fmt.Errorf("artifact_name is required")), false, nil
@@ -194,6 +199,11 @@ func (h *ToolHandler) fetchDefaultArtifact(ctx context.Context, artifactID int64
 }
 
 func (h *ToolHandler) getRepoFile(ctx context.Context, args map[string]any) (string, bool, error) {
+	// Prerequisite gating: must fetch error context before reading source files
+	if !h.hasReadErrorContext && h.HasTestArtifacts() {
+		return errorResult(fmt.Errorf("ACCESS_DENIED: You must fetch test failure data (job logs, artifacts, or traces) before reading source code. Use get_job_logs, get_artifact, or get_test_traces first")), false, nil
+	}
+
 	path, _ := args["path"].(string)
 	if path == "" {
 		return errorResult(fmt.Errorf("path is required")), false, nil
@@ -201,10 +211,40 @@ func (h *ToolHandler) getRepoFile(ctx context.Context, args map[string]any) (str
 
 	content, err := h.GitHub.GetRepoFile(ctx, h.Owner, h.Repo, path)
 	if err != nil {
+		// Smart 404: if file not found, return directory listing of parent
+		if strings.Contains(err.Error(), "404") {
+			return h.smartNotFound(ctx, path), false, nil
+		}
 		return errorResult(err), false, nil
 	}
 
 	return content, false, nil
+}
+
+// smartNotFound returns an error with a directory listing of the parent folder.
+func (h *ToolHandler) smartNotFound(ctx context.Context, path string) string {
+	dir := "."
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		dir = path[:idx]
+	}
+
+	entries, err := h.GitHub.ListDirectory(ctx, h.Owner, h.Repo, dir)
+	if err != nil || len(entries) == 0 {
+		return errorResult(fmt.Errorf("file not found: %s", path))
+	}
+
+	// Limit to 30 entries to avoid huge responses
+	if len(entries) > 30 {
+		entries = entries[:30]
+	}
+
+	result := map[string]any{
+		"error":     fmt.Sprintf("file not found: %s", path),
+		"directory": dir + "/",
+		"contents":  entries,
+	}
+	b, _ := json.Marshal(result)
+	return string(b)
 }
 
 func (h *ToolHandler) findTraceArtifact(name string) *gh.Artifact {
@@ -223,6 +263,7 @@ func (h *ToolHandler) findTraceArtifact(name string) *gh.Artifact {
 }
 
 func (h *ToolHandler) getTestTraces(ctx context.Context, args map[string]any) (string, bool, error) {
+	h.hasReadErrorContext = true
 	h.calledTraces = true
 	name, _ := args["artifact_name"].(string)
 
@@ -286,6 +327,21 @@ func (h *ToolHandler) DiagnosisRCA() *llm.RootCauseAnalysis { return h.rca }
 
 // GetEmitter returns the progress emitter for this handler.
 func (h *ToolHandler) GetEmitter() llm.ProgressEmitter { return h.Emitter }
+
+// HasTestArtifacts returns true if non-expired test-related artifacts exist.
+func (h *ToolHandler) HasTestArtifacts() bool {
+	for _, a := range h.artifacts {
+		if a.Expired {
+			continue
+		}
+		name := strings.ToLower(a.Name)
+		if strings.Contains(name, "report") || strings.Contains(name, "test-results") ||
+			strings.Contains(name, "blob") {
+			return true
+		}
+	}
+	return false
+}
 
 func errorResult(err error) string {
 	b, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/pkg/analysis/tools_test.go
+++ b/pkg/analysis/tools_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	gh "github.com/kamilpajak/heisenberg/pkg/github"
@@ -1121,4 +1122,186 @@ func buildZip(t *testing.T, files map[string][]byte) []byte {
 	}
 	require.NoError(t, w.Close())
 	return buf.Bytes()
+}
+
+func TestPrerequisiteGating_BlocksRepoFileBeforeArtifacts(t *testing.T) {
+	h := &ToolHandler{
+		artifacts: []gh.Artifact{{Name: "playwright-report", Expired: false}},
+	}
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "package.json"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result, "ACCESS_DENIED")
+	assert.Contains(t, result, "fetch test failure data")
+}
+
+func TestPrerequisiteGating_AllowsAfterJobLogs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/logs") {
+			w.Write([]byte("test log output"))
+		} else if strings.Contains(r.URL.Path, "/contents/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"content":  "cGFja2FnZS5qc29u", // base64 "package.json"
+				"encoding": "base64",
+			})
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient(srv.URL, srv.Client())
+	h := &ToolHandler{
+		GitHub:    ghClient,
+		Owner:     "owner",
+		Repo:      "repo",
+		RunID:     123,
+		artifacts: []gh.Artifact{{Name: "playwright-report", Expired: false}},
+	}
+
+	// Before job logs → blocked
+	result, _, _ := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "package.json"},
+	})
+	assert.Contains(t, result, "ACCESS_DENIED")
+
+	// Fetch job logs
+	_, _, _ = h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_job_logs",
+		Args: map[string]any{"job_id": float64(1)},
+	})
+
+	// After job logs → allowed
+	result, _, _ = h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "package.json"},
+	})
+	assert.NotContains(t, result, "ACCESS_DENIED")
+}
+
+func TestPrerequisiteGating_DisabledWhenNoTestArtifacts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content":  "cGFja2FnZS5qc29u",
+			"encoding": "base64",
+		})
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient(srv.URL, srv.Client())
+	h := &ToolHandler{
+		GitHub:    ghClient,
+		Owner:     "owner",
+		Repo:      "repo",
+		RunID:     123,
+		artifacts: []gh.Artifact{}, // no artifacts
+	}
+
+	// No artifacts → get_repo_file allowed immediately
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "package.json"},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, result, "ACCESS_DENIED")
+}
+
+func TestHasTestArtifacts(t *testing.T) {
+	tests := []struct {
+		name      string
+		artifacts []gh.Artifact
+		want      bool
+	}{
+		{"with playwright report", []gh.Artifact{{Name: "playwright-report", Expired: false}}, true},
+		{"with blob report", []gh.Artifact{{Name: "blob-report-1", Expired: false}}, true},
+		{"with test results", []gh.Artifact{{Name: "test-results", Expired: false}}, true},
+		{"with html report", []gh.Artifact{{Name: "html-report--attempt-1", Expired: false}}, true},
+		{"build cache only", []gh.Artifact{{Name: "build-cache", Expired: false}}, false},
+		{"docker image only", []gh.Artifact{{Name: "docker-image.tar", Expired: false}}, false},
+		{"expired report", []gh.Artifact{{Name: "playwright-report", Expired: true}}, false},
+		{"empty", []gh.Artifact{}, false},
+		{"mixed", []gh.Artifact{
+			{Name: "build-cache", Expired: false},
+			{Name: "playwright-report", Expired: false},
+		}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &ToolHandler{artifacts: tt.artifacts}
+			assert.Equal(t, tt.want, h.HasTestArtifacts())
+		})
+	}
+}
+
+func TestSmartNotFound_ReturnsDirectoryListing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if strings.Contains(path, "/contents/tests/auth.spec.ts") {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message": "Not Found"}`))
+		} else if strings.Contains(path, "/contents/tests") {
+			_ = json.NewEncoder(w).Encode([]map[string]string{
+				{"name": "e2e", "type": "dir"},
+				{"name": "setup.ts", "type": "file"},
+				{"name": "utils.ts", "type": "file"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient(srv.URL, srv.Client())
+	h := &ToolHandler{
+		GitHub:              ghClient,
+		Owner:               "owner",
+		Repo:                "repo",
+		RunID:               123,
+		hasReadErrorContext: true, // bypass prerequisite gating
+	}
+
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "tests/auth.spec.ts"},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "file not found")
+	assert.Contains(t, result, "e2e/")
+	assert.Contains(t, result, "setup.ts")
+	assert.Contains(t, result, "contents")
+}
+
+func TestSmartNotFound_RootDirectory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if strings.Contains(path, "/contents/nonexistent.ts") {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message": "Not Found"}`))
+		} else if strings.HasSuffix(path, "/contents/.") || strings.HasSuffix(path, "/contents/") {
+			_ = json.NewEncoder(w).Encode([]map[string]string{
+				{"name": "src", "type": "dir"},
+				{"name": "package.json", "type": "file"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient(srv.URL, srv.Client())
+	h := &ToolHandler{
+		GitHub:              ghClient,
+		Owner:               "owner",
+		Repo:                "repo",
+		RunID:               123,
+		hasReadErrorContext: true,
+	}
+
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "nonexistent.ts"},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "file not found")
+	assert.Contains(t, result, "package.json")
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -460,6 +460,45 @@ func (c *Client) doRequest(ctx context.Context, url string, result interface{}) 
 	return json.NewDecoder(resp.Body).Decode(result)
 }
 
+// ListDirectory returns the names of files and directories at the given path.
+// Directory names have a trailing "/".
+func (c *Client) ListDirectory(ctx context.Context, owner, repo, path string) ([]string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/contents/%s", c.baseURL, owner, repo, path)
+
+	req, err := c.newAPIRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("directory not found: %s", path)
+	}
+
+	var entries []struct {
+		Name string `json:"name"`
+		Type string `json:"type"` // "file" or "dir"
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("failed to parse directory listing: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Type == "dir" {
+			names = append(names, e.Name+"/")
+		} else {
+			names = append(names, e.Name)
+		}
+	}
+	return names, nil
+}
+
 func base64Decode(s string) ([]byte, error) {
 	// GitHub returns base64 with newlines
 	s = strings.ReplaceAll(s, "\n", "")

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -321,3 +321,33 @@ func TestSelectAndFetch(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, ArtifactHTML, result.Type)
 }
+
+func TestListDirectory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{"name": "e2e", "type": "dir"},
+			{"name": "setup.ts", "type": "file"},
+			{"name": "utils.ts", "type": "file"}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL, srv.Client())
+	entries, err := c.ListDirectory(context.Background(), "owner", "repo", "tests")
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+	assert.Equal(t, "e2e/", entries[0])
+	assert.Equal(t, "setup.ts", entries[1])
+}
+
+func TestListDirectory_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL, srv.Client())
+	_, err := c.ListDirectory(context.Background(), "owner", "repo", "nonexistent")
+	assert.Error(t, err)
+}

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -178,13 +178,14 @@ type stepInfo struct {
 
 // loopState tracks mutable state across agent loop iterations.
 type loopState struct {
-	history        []Content
-	pendingDone    bool
-	hasCalledTools bool
-	doneNudged     bool
-	savedText      string
-	calledTools    map[string]bool // tracks tool+args hashes to detect duplicates
-	softWarned     bool            // true after soft limit warning injected
+	history              []Content
+	pendingDone          bool
+	hasCalledTools       bool
+	doneNudged           bool
+	savedText            string
+	calledTools          map[string]bool // tracks tool+args hashes to detect duplicates
+	softWarned           bool            // true after soft limit warning injected
+	consecutiveFileReads int             // counts consecutive get_repo_file/get_workflow_file calls
 }
 
 // RunAgentLoop runs the agentic conversation loop. The model can call tools
@@ -448,6 +449,27 @@ func (c *Client) executeCalls(ctx context.Context, s *loopState, handler ToolExe
 			continue
 		}
 		s.calledTools[key] = true
+
+		// Circuit breaker: track consecutive file reads
+		isFileRead := call.Name == "get_repo_file" || call.Name == "get_workflow_file"
+		if isFileRead {
+			s.consecutiveFileReads++
+		} else {
+			s.consecutiveFileReads = 0
+		}
+
+		// Intercept after 3 consecutive file reads when test artifacts exist
+		if isFileRead && s.consecutiveFileReads > 3 && handler.HasTestArtifacts() {
+			result := `{"error": "CIRCUIT_BREAKER: You have fetched multiple source files consecutively. Review the information you have gathered so far, state your current hypothesis, and determine if you need test artifacts or logs before reading more files."}`
+			emitToolResult(handler, si, ci, len(calls), 0, result)
+			responseParts = append(responseParts, Part{
+				FunctionResponse: &FunctionResponse{
+					Name:     call.Name,
+					Response: map[string]any{"result": result},
+				},
+			})
+			continue
+		}
 
 		t1 := time.Now()
 		result, isDone, err := handler.Execute(ctx, call)

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -264,6 +264,7 @@ func (m *mockToolHandler) DiagnosisConfidence() int         { return m.confidenc
 func (m *mockToolHandler) DiagnosisSensitivity() string     { return m.sensitivity }
 func (m *mockToolHandler) DiagnosisRCA() *RootCauseAnalysis { return nil }
 func (m *mockToolHandler) GetEmitter() ProgressEmitter      { return m.emitter }
+func (m *mockToolHandler) HasTestArtifacts() bool           { return false }
 
 // testToolDeclarations returns minimal tool declarations for tests.
 func testToolDeclarations() []FunctionDeclaration {
@@ -872,4 +873,98 @@ func TestRunAgentLoop_GenerateFinalNoCandidates(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty response")
+}
+
+// mockToolHandlerWithArtifacts has test artifacts (for circuit breaker tests).
+type mockToolHandlerWithArtifacts struct {
+	mockToolHandler
+	executedCalls []string
+}
+
+func (m *mockToolHandlerWithArtifacts) HasTestArtifacts() bool { return true }
+func (m *mockToolHandlerWithArtifacts) Execute(_ context.Context, call FunctionCall) (string, bool, error) {
+	m.executedCalls = append(m.executedCalls, call.Name)
+	if call.Name == "done" {
+		m.category = CategoryDiagnosis
+		m.confidence = 80
+		m.sensitivity = "low"
+		return "", true, nil
+	}
+	return "file content for " + call.Name, false, nil
+}
+
+func TestCircuitBreaker_FiresAfter3ConsecutiveReads(t *testing.T) {
+	c := &Client{}
+	handler := &mockToolHandlerWithArtifacts{mockToolHandler: mockToolHandler{emitter: noopEmitter{}}}
+	s := &loopState{calledTools: make(map[string]bool)}
+	si := &stepInfo{step: 1}
+
+	// 4 consecutive get_repo_file calls — 4th should be intercepted
+	calls := []FunctionCall{
+		{Name: "get_repo_file", Args: map[string]any{"path": "file1.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file2.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file3.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file4.ts"}},
+	}
+
+	parts, _, err := c.executeCalls(context.Background(), s, handler, calls, si)
+	require.NoError(t, err)
+
+	// First 3 should execute, 4th should be circuit breaker error
+	assert.Len(t, parts, 4)
+	lastResult := parts[3].FunctionResponse.Response["result"].(string)
+	assert.Contains(t, lastResult, "CIRCUIT_BREAKER")
+
+	// Only 3 actual executions (4th was intercepted)
+	assert.Len(t, handler.executedCalls, 3)
+}
+
+func TestCircuitBreaker_ResetsOnArtifactFetch(t *testing.T) {
+	c := &Client{}
+	handler := &mockToolHandlerWithArtifacts{mockToolHandler: mockToolHandler{emitter: noopEmitter{}}}
+	s := &loopState{calledTools: make(map[string]bool)}
+	si := &stepInfo{step: 1}
+
+	// 2 file reads, then artifact, then 2 more file reads — no circuit breaker
+	calls := []FunctionCall{
+		{Name: "get_repo_file", Args: map[string]any{"path": "file1.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file2.ts"}},
+		{Name: "get_artifact", Args: map[string]any{"artifact_name": "report"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file3.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file4.ts"}},
+	}
+
+	parts, _, err := c.executeCalls(context.Background(), s, handler, calls, si)
+	require.NoError(t, err)
+
+	// All 5 should execute (no circuit breaker)
+	assert.Len(t, handler.executedCalls, 5)
+	for _, p := range parts {
+		result := p.FunctionResponse.Response["result"].(string)
+		assert.NotContains(t, result, "CIRCUIT_BREAKER")
+	}
+}
+
+func TestCircuitBreaker_NoFireWithoutArtifacts(t *testing.T) {
+	c := &Client{}
+	handler := &mockToolHandler{emitter: noopEmitter{}} // HasTestArtifacts() = false
+	s := &loopState{calledTools: make(map[string]bool)}
+	si := &stepInfo{step: 1}
+
+	calls := []FunctionCall{
+		{Name: "get_repo_file", Args: map[string]any{"path": "file1.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file2.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file3.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file4.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "file5.ts"}},
+	}
+
+	parts, _, err := c.executeCalls(context.Background(), s, handler, calls, si)
+	require.NoError(t, err)
+
+	// No circuit breaker without test artifacts
+	for _, p := range parts {
+		result := p.FunctionResponse.Response["result"].(string)
+		assert.NotContains(t, result, "CIRCUIT_BREAKER")
+	}
 }

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -104,6 +104,7 @@ type ToolExecutor interface {
 	DiagnosisSensitivity() string
 	DiagnosisRCA() *RootCauseAnalysis
 	GetEmitter() ProgressEmitter
+	HasTestArtifacts() bool
 }
 
 // AnalysisResult holds the final output from the agent loop.


### PR DESCRIPTION
## Summary

Fixes #19 — agent loop exhausts 30 iterations on large repos (TryGhost/Ghost, microsoft/playwright) by repeatedly calling `get_repo_file` instead of fetching test artifacts.

Four guardrail mechanisms implemented:

### 1. Prerequisite Gating
`get_repo_file` blocked until AI fetches logs, artifacts, or traces first. Returns `ACCESS_DENIED` error directing the model to use `get_artifact`/`get_job_logs`. Disabled when no test artifacts exist.

### 2. Circuit Breaker
After 3 consecutive `get_repo_file` calls (when test artifacts exist), intercepts the call and returns `CIRCUIT_BREAKER` error forcing the model to review gathered data and state a hypothesis.

### 3. Smart 404
When `get_repo_file` returns 404, returns directory listing of parent folder instead of bare error. Eliminates blind path guessing — model learns repo structure on first miss.

### 4. Better Initial Context
Classifies artifacts as `[TEST REPORT]` and adds explicit `IMPORTANT: Start by fetching test artifacts` instruction when test reports exist.

## Results

| Repo | Before | After |
|------|--------|-------|
| microsoft/playwright | `Error: agent loop exceeded 30 iterations` | Diagnosis with 90% confidence |

## Known Limitation

Circuit breaker fires correctly but AI sometimes ignores the error and continues with `get_repo_file`. Will address in a followup with stronger enforcement (dynamic tool removal).

## Test plan

- [x] Prerequisite gating: blocks before artifacts, allows after, disabled when no artifacts
- [x] Circuit breaker: fires after 3 consecutive reads, resets on artifact fetch, no-op without artifacts
- [x] Smart 404: returns directory listing on file not found
- [x] Initial context: classifies test artifacts, adds IMPORTANT instruction
- [x] Full suite passes: `go test -race ./...` (14 packages, 0 failures)
- [x] E2E: microsoft/playwright produces diagnosis instead of timeout
- [ ] CI pipeline passes