### PR TITLE
fix: strengthen circuit breaker with dynamic tool removal

### DIFF
--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -186,6 +186,7 @@ type loopState struct {
 	calledTools          map[string]bool // tracks tool+args hashes to detect duplicates
 	softWarned           bool            // true after soft limit warning injected
 	consecutiveFileReads int             // counts consecutive get_repo_file/get_workflow_file calls
+	fileToolsHiddenUntil int             // iteration index after which file tools are restored
 }
 
 // RunAgentLoop runs the agentic conversation loop. The model can call tools
@@ -220,7 +221,8 @@ func (c *Client) RunAgentLoop(ctx context.Context, handler ToolExecutor, toolDec
 		}
 		emit(handler, ProgressEvent{Type: "step", Step: si.step, MaxStep: maxIterations, Message: stepMsg})
 
-		candidate, err := c.callModel(ctx, s, tools, system, handler, si)
+		currentTools := activeTools(tools, s, i)
+		candidate, err := c.callModel(ctx, s, currentTools, system, handler, si)
 		if err != nil {
 			return nil, err
 		}
@@ -460,7 +462,8 @@ func (c *Client) executeCalls(ctx context.Context, s *loopState, handler ToolExe
 
 		// Intercept after 3 consecutive file reads when test artifacts exist
 		if isFileRead && s.consecutiveFileReads > 3 && handler.HasTestArtifacts() {
-			result := `{"error": "CIRCUIT_BREAKER: You have fetched multiple source files consecutively. Review the information you have gathered so far, state your current hypothesis, and determine if you need test artifacts or logs before reading more files."}`
+			s.fileToolsHiddenUntil = si.iteration + 3 // hide file tools for next 2 iterations
+			result := `{"error": "CIRCUIT_BREAKER: You have fetched multiple source files consecutively. File reading is temporarily disabled. Use get_artifact, get_job_logs, or get_test_traces to analyze test failures, then call done with your diagnosis."}`
 			emitToolResult(handler, si, ci, len(calls), 0, result)
 			responseParts = append(responseParts, Part{
 				FunctionResponse: &FunctionResponse{
@@ -492,6 +495,26 @@ func (c *Client) executeCalls(ctx context.Context, s *loopState, handler ToolExe
 		})
 	}
 	return responseParts, done, nil
+}
+
+// activeTools returns the tool list for the current iteration,
+// hiding file tools during circuit breaker cooldown.
+func activeTools(tools []Tool, s *loopState, iteration int) []Tool {
+	if s.fileToolsHiddenUntil > iteration {
+		return filterFileTools(tools)
+	}
+	return tools
+}
+
+// filterFileTools returns a copy of tools without get_repo_file and get_workflow_file.
+func filterFileTools(tools []Tool) []Tool {
+	var filtered []FunctionDeclaration
+	for _, decl := range tools[0].FunctionDeclarations {
+		if decl.Name != "get_repo_file" && decl.Name != "get_workflow_file" {
+			filtered = append(filtered, decl)
+		}
+	}
+	return []Tool{{FunctionDeclarations: filtered}}
 }
 
 // emitToolResult sends a verbose progress event for a completed tool call.

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -22,6 +22,8 @@ func emit(h ToolExecutor, ev ProgressEvent) {
 
 const maxIterations = 30
 const softLimitIteration = 15
+const circuitBreakerThreshold = 3 // consecutive file reads before breaker fires
+const circuitBreakerCooldown = 3  // iterations to hide file tools (current + 2 more)
 
 var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
@@ -461,8 +463,8 @@ func (c *Client) executeCalls(ctx context.Context, s *loopState, handler ToolExe
 		}
 
 		// Intercept after 3 consecutive file reads when test artifacts exist
-		if isFileRead && s.consecutiveFileReads > 3 && handler.HasTestArtifacts() {
-			s.fileToolsHiddenUntil = si.iteration + 3 // hide file tools for next 2 iterations
+		if isFileRead && s.consecutiveFileReads > circuitBreakerThreshold && handler.HasTestArtifacts() {
+			s.fileToolsHiddenUntil = si.iteration + circuitBreakerCooldown
 			result := `{"error": "CIRCUIT_BREAKER: You have fetched multiple source files consecutively. File reading is temporarily disabled. Use get_artifact, get_job_logs, or get_test_traces to analyze test failures, then call done with your diagnosis."}`
 			emitToolResult(handler, si, ci, len(calls), 0, result)
 			responseParts = append(responseParts, Part{
@@ -508,13 +510,17 @@ func activeTools(tools []Tool, s *loopState, iteration int) []Tool {
 
 // filterFileTools returns a copy of tools without get_repo_file and get_workflow_file.
 func filterFileTools(tools []Tool) []Tool {
-	var filtered []FunctionDeclaration
-	for _, decl := range tools[0].FunctionDeclarations {
-		if decl.Name != "get_repo_file" && decl.Name != "get_workflow_file" {
-			filtered = append(filtered, decl)
+	result := make([]Tool, 0, len(tools))
+	for _, t := range tools {
+		var filtered []FunctionDeclaration
+		for _, decl := range t.FunctionDeclarations {
+			if decl.Name != "get_repo_file" && decl.Name != "get_workflow_file" {
+				filtered = append(filtered, decl)
+			}
 		}
+		result = append(result, Tool{FunctionDeclarations: filtered})
 	}
-	return []Tool{{FunctionDeclarations: filtered}}
+	return result
 }
 
 // emitToolResult sends a verbose progress event for a completed tool call.

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -968,3 +968,60 @@ func TestCircuitBreaker_NoFireWithoutArtifacts(t *testing.T) {
 		assert.NotContains(t, result, "CIRCUIT_BREAKER")
 	}
 }
+
+func TestFilterFileTools(t *testing.T) {
+	tools := []Tool{{FunctionDeclarations: []FunctionDeclaration{
+		{Name: "get_job_logs"},
+		{Name: "get_artifact"},
+		{Name: "get_repo_file"},
+		{Name: "get_workflow_file"},
+		{Name: "get_test_traces"},
+		{Name: "done"},
+	}}}
+
+	filtered := filterFileTools(tools)
+
+	assert.Len(t, filtered[0].FunctionDeclarations, 4)
+	for _, d := range filtered[0].FunctionDeclarations {
+		assert.NotEqual(t, "get_repo_file", d.Name)
+		assert.NotEqual(t, "get_workflow_file", d.Name)
+	}
+}
+
+func TestCircuitBreaker_SetsHiddenUntil(t *testing.T) {
+	c := &Client{}
+	handler := &mockToolHandlerWithArtifacts{mockToolHandler: mockToolHandler{emitter: noopEmitter{}}}
+	s := &loopState{calledTools: make(map[string]bool)}
+	si := &stepInfo{step: 5, iteration: 4}
+
+	calls := []FunctionCall{
+		{Name: "get_repo_file", Args: map[string]any{"path": "f1.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "f2.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "f3.ts"}},
+		{Name: "get_repo_file", Args: map[string]any{"path": "f4.ts"}},
+	}
+
+	_, _, err := c.executeCalls(context.Background(), s, handler, calls, si)
+	require.NoError(t, err)
+
+	// After circuit breaker fires, fileToolsHiddenUntil should be set
+	assert.Greater(t, s.fileToolsHiddenUntil, si.iteration)
+}
+
+func TestActiveTools_HidesFileToolsDuringCooldown(t *testing.T) {
+	tools := []Tool{{FunctionDeclarations: []FunctionDeclaration{
+		{Name: "get_job_logs"},
+		{Name: "get_repo_file"},
+		{Name: "done"},
+	}}}
+
+	s := &loopState{fileToolsHiddenUntil: 5}
+
+	// Iteration 3: tools should be hidden (3 < 5)
+	active := activeTools(tools, s, 3)
+	assert.Len(t, active[0].FunctionDeclarations, 2) // get_job_logs + done
+
+	// Iteration 5: tools should be restored (5 >= 5)
+	active = activeTools(tools, s, 5)
+	assert.Len(t, active[0].FunctionDeclarations, 3) // all tools back
+}


### PR DESCRIPTION
## Summary
- When the circuit breaker fires after 3+ consecutive file reads, **file tools are now temporarily removed** from the tool list for 2 iterations, forcing the agent to use artifact/log/trace tools instead of just ignoring the warning message
- Adds `activeTools()` function that filters out `get_repo_file` and `get_workflow_file` during cooldown
- File tools are automatically restored after the cooldown period

## Test plan
- [x] Unit tests: `TestFilterFileTools`, `TestCircuitBreaker_SetsHiddenUntil`, `TestActiveTools_HidesFileToolsDuringCooldown`
- [x] All existing tests pass (`go test -race ./...`)
- [x] E2E verified on `microsoft/playwright --run-id 23642131867`: agent used 13/30 tool calls, reached 90% confidence, no loops

Closes #19