### PR TITLE
feat: add bug_location classification to RCA (#20)

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -209,15 +209,11 @@ func printResult(stderr, stdout io.Writer, r *llm.AnalysisResult) {
 	}
 }
 
-func printStructuredRCA(w io.Writer, rca *llm.RootCauseAnalysis) {
-	bold := color.New(color.Bold)
-	dim := color.New(color.FgHiBlack)
+// renderRCAHeader prints the failure type, location, bug location tag, and suspected bug file.
+func renderRCAHeader(w io.Writer, rca *llm.RootCauseAnalysis) {
 	headerColor := color.New(color.Bold, color.FgRed)
-	sectionColor := color.New(color.Bold, color.FgWhite)
-	fixColor := color.New(color.Bold, color.FgGreen)
-	separator := "  " + strings.Repeat("─", 40)
+	dim := color.New(color.FgHiBlack)
 
-	// Header with failure type and location
 	failureType := strings.ToUpper(rca.FailureType)
 	if failureType == "" {
 		failureType = "ERROR"
@@ -225,27 +221,35 @@ func printStructuredRCA(w io.Writer, rca *llm.RootCauseAnalysis) {
 
 	header := failureType
 	if rca.Location != nil && rca.Location.FilePath != "" {
-		loc := rca.Location.FilePath
-		if rca.Location.LineNumber > 0 {
-			loc = fmt.Sprintf("%s:%d", rca.Location.FilePath, rca.Location.LineNumber)
-		}
+		loc := formatCodeLocation(rca.Location)
 		header = fmt.Sprintf("%s in %s", header, loc)
 	}
-	// Append bug location tag based on confidence
 	if tag := bugLocationTag(rca.BugLocation, rca.BugLocationConfidence); tag != "" {
 		header += "  " + tag
 	}
 	_, _ = headerColor.Fprintln(w, "  "+header)
 
-	// Show suspected bug code location if available
 	if rca.BugCodeLocation != nil && rca.BugCodeLocation.FilePath != "" {
-		loc := rca.BugCodeLocation.FilePath
-		if rca.BugCodeLocation.LineNumber > 0 {
-			loc = fmt.Sprintf("%s:%d", rca.BugCodeLocation.FilePath, rca.BugCodeLocation.LineNumber)
-		}
-		_, _ = dim.Fprintf(w, "  Bug location: %s\n", loc)
+		_, _ = dim.Fprintf(w, "  Bug location: %s\n", formatCodeLocation(rca.BugCodeLocation))
 	}
 	fmt.Fprintln(w)
+}
+
+func formatCodeLocation(loc *llm.CodeLocation) string {
+	if loc.LineNumber > 0 {
+		return fmt.Sprintf("%s:%d", loc.FilePath, loc.LineNumber)
+	}
+	return loc.FilePath
+}
+
+func printStructuredRCA(w io.Writer, rca *llm.RootCauseAnalysis) {
+	bold := color.New(color.Bold)
+	dim := color.New(color.FgHiBlack)
+	sectionColor := color.New(color.Bold, color.FgWhite)
+	fixColor := color.New(color.Bold, color.FgGreen)
+	separator := "  " + strings.Repeat("─", 40)
+
+	renderRCAHeader(w, rca)
 
 	// Root cause
 	_, _ = sectionColor.Fprintln(w, "  Root Cause")

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -231,7 +231,20 @@ func printStructuredRCA(w io.Writer, rca *llm.RootCauseAnalysis) {
 		}
 		header = fmt.Sprintf("%s in %s", header, loc)
 	}
+	// Append bug location tag based on confidence
+	if tag := bugLocationTag(rca.BugLocation, rca.BugLocationConfidence); tag != "" {
+		header += "  " + tag
+	}
 	_, _ = headerColor.Fprintln(w, "  "+header)
+
+	// Show suspected bug code location if available
+	if rca.BugCodeLocation != nil && rca.BugCodeLocation.FilePath != "" {
+		loc := rca.BugCodeLocation.FilePath
+		if rca.BugCodeLocation.LineNumber > 0 {
+			loc = fmt.Sprintf("%s:%d", rca.BugCodeLocation.FilePath, rca.BugCodeLocation.LineNumber)
+		}
+		_, _ = dim.Fprintf(w, "  Bug location: %s\n", loc)
+	}
 	fmt.Fprintln(w)
 
 	// Root cause
@@ -324,6 +337,23 @@ func wrapBullets(s string, maxWidth int, indent string) string {
 		out = append(out, wrapped)
 	}
 	return strings.Join(out, "\n")
+}
+
+func bugLocationTag(loc llm.BugLocation, confidence string) string {
+	switch loc {
+	case llm.BugLocationProduction:
+		if confidence == "low" {
+			return "[production bug?]"
+		}
+		return "[production bug]"
+	case llm.BugLocationInfrastructure:
+		if confidence == "low" {
+			return "[infrastructure?]"
+		}
+		return "[infrastructure]"
+	default:
+		return ""
+	}
 }
 
 func evidenceIcon(t string) string {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -120,6 +120,99 @@ func TestJSONOutput(t *testing.T) {
 	assert.Equal(t, r.Sensitivity, decoded.Sensitivity)
 }
 
+func TestPrintStructuredRCA_ProductionBug_HighConfidence(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:                 "Price calculation broken",
+		FailureType:           llm.FailureTypeAssertion,
+		Location:              &llm.CodeLocation{FilePath: "tests/checkout.spec.ts", LineNumber: 45},
+		BugLocation:           llm.BugLocationProduction,
+		BugLocationConfidence: "high",
+		BugCodeLocation:       &llm.CodeLocation{FilePath: "src/pricing.ts", LineNumber: 42},
+		RootCause:             "Pricing returns zero",
+		Remediation:           "Fix calculatePrice()",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "ASSERTION")
+	assert.Contains(t, out, "tests/checkout.spec.ts:45")
+	assert.Contains(t, out, "[production bug]")
+	assert.Contains(t, out, "src/pricing.ts:42")
+}
+
+func TestPrintStructuredRCA_ProductionBug_LowConfidence(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:                 "Possible regression",
+		FailureType:           llm.FailureTypeAssertion,
+		Location:              &llm.CodeLocation{FilePath: "tests/checkout.spec.ts", LineNumber: 45},
+		BugLocation:           llm.BugLocationProduction,
+		BugLocationConfidence: "low",
+		RootCause:             "Maybe a regression",
+		Remediation:           "Investigate",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "[production bug?]")
+	assert.NotContains(t, out, "[production bug]  ") // no exact match without ?
+}
+
+func TestPrintStructuredRCA_TestBug_NoTag(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:       "Wrong assertion",
+		FailureType: llm.FailureTypeAssertion,
+		BugLocation: llm.BugLocationTest,
+		RootCause:   "Test has wrong expected value",
+		Remediation: "Update test",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.NotContains(t, out, "[production")
+	assert.NotContains(t, out, "[infrastructure")
+	assert.NotContains(t, out, "[test") // test is default — no tag
+}
+
+func TestPrintStructuredRCA_InfraBug(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:                 "DB not seeded",
+		FailureType:           llm.FailureTypeInfra,
+		BugLocation:           llm.BugLocationInfrastructure,
+		BugLocationConfidence: "high",
+		RootCause:             "CI database empty",
+		Remediation:           "Fix seed step",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "[infrastructure]")
+}
+
+func TestPrintStructuredRCA_UnknownBugLocation_NoTag(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:       "Unclear failure",
+		FailureType: llm.FailureTypeAssertion,
+		BugLocation: llm.BugLocationUnknown,
+		RootCause:   "Not enough evidence",
+		Remediation: "Investigate",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.NotContains(t, out, "[production")
+	assert.NotContains(t, out, "[infrastructure")
+}
+
 func TestPrintResult_WithStructuredRCA(t *testing.T) {
 	var stderr, stdout bytes.Buffer
 	r := &llm.AnalysisResult{

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -76,14 +76,22 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 
 	initialContext := buildInitialContext(wfRun, jobs, artifacts)
 
+	// Detect PR number from workflow run metadata
+	var prNumber int
+	if len(wfRun.PullRequests) > 0 {
+		prNumber = wfRun.PullRequests[0].Number
+	}
+
 	handler := &ToolHandler{
 		GitHub:       ghClient,
 		Owner:        p.Owner,
 		Repo:         p.Repo,
 		RunID:        resolvedRunID,
+		PRNumber:     prNumber,
+		HeadSHA:      wfRun.HeadSHA,
 		SnapshotHTML: p.SnapshotHTML,
 		Emitter:      p.Emitter,
-		artifacts:    artifacts, // pre-populate so HasTestArtifacts() works immediately
+		artifacts:    artifacts,
 	}
 
 	llmClient, err := llm.NewClient()

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -17,6 +17,8 @@ type ToolHandler struct {
 	Owner        string
 	Repo         string
 	RunID        int64
+	PRNumber     int    // detected PR number (0 = none)
+	HeadSHA      string // commit SHA for compare fallback
 	SnapshotHTML func([]byte) ([]byte, error)
 	Emitter      llm.ProgressEmitter
 
@@ -45,6 +47,8 @@ func (h *ToolHandler) Execute(ctx context.Context, call llm.FunctionCall) (strin
 		return h.getRepoFile(ctx, call.Args)
 	case "get_test_traces":
 		return h.getTestTraces(ctx, call.Args)
+	case "get_pr_diff":
+		return h.getPRDiff(ctx, call.Args)
 	case "done":
 		return h.handleDone(call.Args)
 	default:
@@ -395,6 +399,130 @@ func stringArgOrDefault(args map[string]any, key string, def string) string {
 	return s
 }
 
+// classifyFilePath categorizes a file path as test, production, config, or other.
+func classifyFilePath(path string) string {
+	lower := strings.ToLower(path)
+
+	// Ignored files → other
+	for _, pattern := range []string{"lock.json", "lock.yaml", "lock.yml", ".md", ".png", ".svg", ".jpg", ".gif", "assets/", "docs/"} {
+		if strings.Contains(lower, pattern) {
+			return "other"
+		}
+	}
+
+	// Config
+	for _, pattern := range []string{".github/", "dockerfile", ".yml", ".yaml", "makefile", "docker-compose"} {
+		if strings.Contains(lower, pattern) {
+			return "config"
+		}
+	}
+
+	// Test
+	for _, pattern := range []string{"test", ".spec.", "_test.go", "fixture"} {
+		if strings.Contains(lower, pattern) {
+			return "test"
+		}
+	}
+
+	// Production code
+	for _, pattern := range []string{"src/", "app/", "pkg/", "lib/", "internal/", "cmd/", ".go", ".ts", ".js", ".py", ".rb", ".rs"} {
+		if strings.Contains(lower, pattern) {
+			return "production"
+		}
+	}
+
+	return "other"
+}
+
+type prDiffResponse struct {
+	Kind       string     `json:"kind"`
+	PRNumber   int        `json:"pr_number,omitempty"`
+	TotalFiles int        `json:"total_files"`
+	Files      []diffFile `json:"files"`
+}
+
+type diffFile struct {
+	Path      string `json:"path"`
+	Status    string `json:"status"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Category  string `json:"category"`
+	Patch     string `json:"patch,omitempty"`
+}
+
+func (h *ToolHandler) getPRDiff(ctx context.Context, args map[string]any) (string, bool, error) {
+	var files []gh.PRFile
+	kind := "none"
+
+	if h.PRNumber > 0 {
+		kind = "pull_request"
+		var err error
+		files, err = h.GitHub.GetPRFiles(ctx, h.Owner, h.Repo, h.PRNumber)
+		if err != nil {
+			return errorResult(err), false, nil
+		}
+	} else if h.HeadSHA != "" {
+		// Fallback: compare against default branch (assume "main")
+		kind = "commit_range"
+		var err error
+		files, err = h.GitHub.CompareCommits(ctx, h.Owner, h.Repo, "main", h.HeadSHA)
+		if err != nil {
+			// If compare fails, return kind: "none"
+			kind = "none"
+			files = nil
+		}
+	}
+
+	// Build structured response
+	resp := prDiffResponse{
+		Kind:     kind,
+		PRNumber: h.PRNumber,
+	}
+
+	// Parse suspected_files for prioritization
+	suspectedFiles := map[string]bool{}
+	if raw, ok := args["suspected_files"].([]any); ok {
+		for _, f := range raw {
+			if s, ok := f.(string); ok {
+				suspectedFiles[s] = true
+			}
+		}
+	}
+
+	const maxPatchTokens = 4000
+	patchBudget := maxPatchTokens
+
+	for _, f := range files {
+		cat := classifyFilePath(f.Path)
+		if cat == "other" {
+			continue // skip lockfiles, docs, assets
+		}
+
+		df := diffFile{
+			Path:      f.Path,
+			Status:    f.Status,
+			Additions: f.Additions,
+			Deletions: f.Deletions,
+			Category:  cat,
+		}
+
+		// Include patch for suspected files and within budget
+		patchLen := len(f.Patch) / 4 // rough token estimate
+		if f.Patch != "" && patchBudget > 0 && (suspectedFiles[f.Path] || patchLen < 500) {
+			if patchLen <= patchBudget {
+				df.Patch = f.Patch
+				patchBudget -= patchLen
+			}
+		}
+
+		resp.Files = append(resp.Files, df)
+	}
+	resp.TotalFiles = len(resp.Files)
+
+	data, _ := json.Marshal(resp)
+	return string(data), false, nil
+}
+
 // ToolDeclarations returns the function declarations for all available tools.
 func ToolDeclarations() []llm.FunctionDeclaration {
 	return []llm.FunctionDeclaration{
@@ -453,6 +581,20 @@ func ToolDeclarations() []llm.FunctionDeclaration {
 				Type: "object",
 				Properties: map[string]llm.Schema{
 					"artifact_name": {Type: "string"},
+				},
+			},
+		},
+		{
+			Name:        "get_pr_diff",
+			Description: "Get the diff of changed files for this PR/commit. Returns file list with categories (test/production/config) and optional patch hunks. Use this before determining bug_location. Pass suspected_files from stack traces to prioritize their patches.",
+			Parameters: &llm.Schema{
+				Type: "object",
+				Properties: map[string]llm.Schema{
+					"suspected_files": {
+						Type:        "array",
+						Description: "File paths from stack traces or logs to prioritize in the diff.",
+						Items:       &llm.Schema{Type: "string"},
+					},
 				},
 			},
 		},

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -484,6 +484,24 @@ func ToolDeclarations() []llm.FunctionDeclaration {
 						Type:        "number",
 						Description: "Line number in the test file where failure occurred.",
 					},
+					"bug_location": {
+						Type:        "string",
+						Description: "Where the underlying defect lives. 'test': bug in test code/fixtures/mocks. 'production': test correctly detected a regression in application code. 'infrastructure': CI environment issue. 'unknown': not enough evidence.",
+						Enum:        []string{"test", "production", "infrastructure", "unknown"},
+					},
+					"bug_location_confidence": {
+						Type:        "string",
+						Description: "Confidence in bug_location. 'high': strong evidence. 'medium': probable. 'low': mostly guessing.",
+						Enum:        []string{"high", "medium", "low"},
+					},
+					"bug_code_file_path": {
+						Type:        "string",
+						Description: "When bug_location is 'production' or 'infrastructure', the suspected defect file path (e.g., 'src/pricing.ts'). Leave empty if unclear.",
+					},
+					"bug_code_line_number": {
+						Type:        "number",
+						Description: "Line number in the suspected bug file. Leave empty if unclear.",
+					},
 					"symptom": {
 						Type:        "string",
 						Description: "What failed - the observable error message or behavior.",

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -451,76 +451,71 @@ type diffFile struct {
 }
 
 func (h *ToolHandler) getPRDiff(ctx context.Context, args map[string]any) (string, bool, error) {
-	var files []gh.PRFile
-	kind := "none"
+	files, kind := h.fetchDiffFiles(ctx)
 
-	if h.PRNumber > 0 {
-		kind = "pull_request"
-		var err error
-		files, err = h.GitHub.GetPRFiles(ctx, h.Owner, h.Repo, h.PRNumber)
-		if err != nil {
-			return errorResult(err), false, nil
-		}
-	} else if h.HeadSHA != "" {
-		// Fallback: compare against default branch (assume "main")
-		kind = "commit_range"
-		var err error
-		files, err = h.GitHub.CompareCommits(ctx, h.Owner, h.Repo, "main", h.HeadSHA)
-		if err != nil {
-			// If compare fails, return kind: "none"
-			kind = "none"
-			files = nil
-		}
-	}
-
-	// Build structured response
-	resp := prDiffResponse{
-		Kind:     kind,
-		PRNumber: h.PRNumber,
-	}
-
-	// Parse suspected_files for prioritization
-	suspectedFiles := map[string]bool{}
-	if raw, ok := args["suspected_files"].([]any); ok {
-		for _, f := range raw {
-			if s, ok := f.(string); ok {
-				suspectedFiles[s] = true
-			}
-		}
-	}
-
-	const maxPatchTokens = 4000
-	patchBudget := maxPatchTokens
-
-	for _, f := range files {
-		cat := classifyFilePath(f.Path)
-		if cat == "other" {
-			continue // skip lockfiles, docs, assets
-		}
-
-		df := diffFile{
-			Path:      f.Path,
-			Status:    f.Status,
-			Additions: f.Additions,
-			Deletions: f.Deletions,
-			Category:  cat,
-		}
-
-		// Include patch for suspected files and within budget
-		patchLen := len(f.Patch) / 4 // rough token estimate
-		if f.Patch != "" && patchBudget > 0 && (suspectedFiles[f.Path] || patchLen < 500) {
-			if patchLen <= patchBudget {
-				df.Patch = f.Patch
-				patchBudget -= patchLen
-			}
-		}
-
-		resp.Files = append(resp.Files, df)
-	}
+	resp := prDiffResponse{Kind: kind, PRNumber: h.PRNumber}
+	suspectedFiles := parseSuspectedFiles(args)
+	resp.Files = buildDiffFiles(files, suspectedFiles)
 	resp.TotalFiles = len(resp.Files)
 
 	data, _ := json.Marshal(resp)
 	return string(data), false, nil
+}
+
+func (h *ToolHandler) fetchDiffFiles(ctx context.Context) ([]gh.PRFile, string) {
+	if h.PRNumber > 0 {
+		files, err := h.GitHub.GetPRFiles(ctx, h.Owner, h.Repo, h.PRNumber)
+		if err == nil {
+			return files, "pull_request"
+		}
+	}
+	if h.HeadSHA != "" {
+		files, err := h.GitHub.CompareCommits(ctx, h.Owner, h.Repo, "main", h.HeadSHA)
+		if err == nil {
+			return files, "commit_range"
+		}
+	}
+	return nil, "none"
+}
+
+func parseSuspectedFiles(args map[string]any) map[string]bool {
+	result := map[string]bool{}
+	if raw, ok := args["suspected_files"].([]any); ok {
+		for _, f := range raw {
+			if s, ok := f.(string); ok {
+				result[s] = true
+			}
+		}
+	}
+	return result
+}
+
+func buildDiffFiles(files []gh.PRFile, suspected map[string]bool) []diffFile {
+	const maxPatchTokens = 4000
+	budget := maxPatchTokens
+	var result []diffFile
+
+	for _, f := range files {
+		cat := classifyFilePath(f.Path)
+		if cat == "other" {
+			continue
+		}
+
+		df := diffFile{
+			Path: f.Path, Status: f.Status,
+			Additions: f.Additions, Deletions: f.Deletions,
+			Category: cat,
+		}
+
+		patchLen := len(f.Patch) / 4
+		if f.Patch != "" && budget > 0 && (suspected[f.Path] || patchLen < 500) && patchLen <= budget {
+			df.Patch = f.Patch
+			budget -= patchLen
+		}
+
+		result = append(result, df)
+	}
+	return result
 }
 
 // ToolDeclarations returns the function declarations for all available tools.

--- a/pkg/analysis/tools_test.go
+++ b/pkg/analysis/tools_test.go
@@ -1078,8 +1078,9 @@ func TestToolDeclarations(t *testing.T) {
 	assert.Contains(t, names, "get_workflow_file")
 	assert.Contains(t, names, "get_repo_file")
 	assert.Contains(t, names, "get_test_traces")
+	assert.Contains(t, names, "get_pr_diff")
 	assert.Contains(t, names, "done")
-	assert.Len(t, decls, 7)
+	assert.Len(t, decls, 8)
 }
 
 func TestToolDeclarations_DoneEvidenceArrayHasItems(t *testing.T) {
@@ -1304,4 +1305,104 @@ func TestSmartNotFound_RootDirectory(t *testing.T) {
 
 	assert.Contains(t, result, "file not found")
 	assert.Contains(t, result, "package.json")
+}
+
+func TestClassifyFilePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"tests/checkout.spec.ts", "test"},
+		{"src/components/Button.test.tsx", "test"},
+		{"pkg/analysis/tools_test.go", "test"},
+		{"test/fixtures/data.json", "test"},
+		{"src/pricing.ts", "production"},
+		{"app/models/user.rb", "production"},
+		{"pkg/llm/client.go", "production"},
+		{"lib/utils.js", "production"},
+		{".github/workflows/ci.yml", "config"},
+		{"Dockerfile", "config"},
+		{"docker-compose.yml", "config"},
+		{"Makefile", "config"},
+		{"README.md", "other"},
+		{"docs/guide.md", "other"},
+		{"package-lock.json", "other"},
+		{"pnpm-lock.yaml", "other"},
+		{"assets/logo.png", "other"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, classifyFilePath(tt.path), "classifyFilePath(%q)", tt.path)
+	}
+}
+
+func TestGetPRDiff_WithPR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/pulls/42/files") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[
+				{"filename": "src/pricing.ts", "status": "modified", "additions": 20, "deletions": 5, "patch": "@@ -40,6 +40,7 @@\n+return 0"},
+				{"filename": "tests/checkout.spec.ts", "status": "modified", "additions": 3, "deletions": 1, "patch": "@@ -10 @@"},
+				{"filename": "package-lock.json", "status": "modified", "additions": 500, "deletions": 400, "patch": ""}
+			]`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	h := &ToolHandler{
+		GitHub:   gh.NewTestClient(srv.URL, srv.Client()),
+		Owner:    "owner",
+		Repo:     "repo",
+		PRNumber: 42,
+	}
+
+	result, isDone, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_pr_diff",
+		Args: map[string]any{},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, isDone)
+
+	// Parse structured response
+	var diff struct {
+		Kind       string `json:"kind"`
+		PRNumber   int    `json:"pr_number"`
+		TotalFiles int    `json:"total_files"`
+		Files      []struct {
+			Path     string `json:"path"`
+			Category string `json:"category"`
+			Patch    string `json:"patch"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result), &diff))
+
+	assert.Equal(t, "pull_request", diff.Kind)
+	assert.Equal(t, 42, diff.PRNumber)
+	// package-lock.json should be filtered
+	assert.Equal(t, 2, diff.TotalFiles)
+	assert.Equal(t, "production", diff.Files[0].Category)
+	assert.Equal(t, "test", diff.Files[1].Category)
+}
+
+func TestGetPRDiff_NoPR(t *testing.T) {
+	h := &ToolHandler{
+		Owner:    "owner",
+		Repo:     "repo",
+		PRNumber: 0,
+	}
+
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_pr_diff",
+		Args: map[string]any{},
+	})
+
+	require.NoError(t, err)
+
+	var diff struct {
+		Kind string `json:"kind"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(result), &diff))
+	assert.Equal(t, "none", diff.Kind)
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -103,6 +103,18 @@ type WorkflowRun struct {
 	Path         string `json:"path"`
 	DisplayTitle string `json:"display_title"`
 	CreatedAt    string `json:"created_at"`
+	PullRequests []struct {
+		Number int `json:"number"`
+	} `json:"pull_requests"`
+}
+
+// PRFile represents a file changed in a pull request or commit comparison.
+type PRFile struct {
+	Path      string `json:"filename"`
+	Status    string `json:"status"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Patch     string `json:"patch"`
 }
 
 // Job represents a GitHub Actions job within a workflow run
@@ -497,6 +509,28 @@ func (c *Client) ListDirectory(ctx context.Context, owner, repo, path string) ([
 		}
 	}
 	return names, nil
+}
+
+// GetPRFiles returns the list of files changed in a pull request.
+func (c *Client) GetPRFiles(ctx context.Context, owner, repo string, prNumber int) ([]PRFile, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files", c.baseURL, owner, repo, prNumber)
+	var files []PRFile
+	if err := c.doRequest(ctx, url, &files); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// CompareCommits returns files changed between two refs (branches, tags, or SHAs).
+func (c *Client) CompareCommits(ctx context.Context, owner, repo, base, head string) ([]PRFile, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/compare/%s...%s", c.baseURL, owner, repo, base, head)
+	var result struct {
+		Files []PRFile `json:"files"`
+	}
+	if err := c.doRequest(ctx, url, &result); err != nil {
+		return nil, err
+	}
+	return result.Files, nil
 }
 
 func base64Decode(s string) ([]byte, error) {

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -351,3 +351,70 @@ func TestListDirectory_NotFound(t *testing.T) {
 	_, err := c.ListDirectory(context.Background(), "owner", "repo", "nonexistent")
 	assert.Error(t, err)
 }
+
+func TestGetPRFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/owner/repo/pulls/42/files", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{"filename": "src/pricing.ts", "status": "modified", "additions": 20, "deletions": 5, "patch": "@@ -40,6 +40,7 @@\n+  return 0"},
+			{"filename": "tests/checkout.spec.ts", "status": "modified", "additions": 3, "deletions": 1, "patch": "@@ -10,3 +10,5 @@"}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL, srv.Client())
+	files, err := c.GetPRFiles(context.Background(), "owner", "repo", 42)
+
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	assert.Equal(t, "src/pricing.ts", files[0].Path)
+	assert.Equal(t, "modified", files[0].Status)
+	assert.Equal(t, 20, files[0].Additions)
+	assert.Equal(t, 5, files[0].Deletions)
+	assert.Contains(t, files[0].Patch, "return 0")
+	assert.Equal(t, "tests/checkout.spec.ts", files[1].Path)
+}
+
+func TestCompareCommits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/owner/repo/compare/main...abc123", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"files": [
+				{"filename": "src/app.ts", "status": "added", "additions": 50, "deletions": 0, "patch": "@@ -0,0 +1,50 @@"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL, srv.Client())
+	files, err := c.CompareCommits(context.Background(), "owner", "repo", "main", "abc123")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "src/app.ts", files[0].Path)
+	assert.Equal(t, "added", files[0].Status)
+	assert.Equal(t, 50, files[0].Additions)
+}
+
+func TestWorkflowRun_PullRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"id": 123,
+			"head_branch": "feature/test",
+			"head_sha": "abc",
+			"event": "pull_request",
+			"pull_requests": [{"number": 42}]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL, srv.Client())
+	run, err := c.GetWorkflowRun(context.Background(), "owner", "repo", 123)
+
+	require.NoError(t, err)
+	require.Len(t, run.PullRequests, 1)
+	assert.Equal(t, 42, run.PullRequests[0].Number)
+}

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -161,8 +161,15 @@ Bug location classification:
   - "infrastructure": CI environment, database, network, or config issue
   - "unknown": Not enough evidence — use this instead of guessing
 
+  IMPORTANT: Before determining bug_location, call get_pr_diff with suspected file paths from logs.
+  Key diff signals:
+  - Only test files changed → bug_location="test"
+  - Production code changed + test fails on those paths → bug_location="production"
+  - Only CI config changed → bug_location="infrastructure"
+  - No diff available → rely on logs and stack traces alone
+
   Choose "test" when: stack trace is entirely in test files, expected value is outdated, assertion is brittle.
-  Choose "production" when: stack trace shows exception in app code, actual values indicate logic bug, test passes on main but fails in PR.
+  Choose "production" when: stack trace shows exception in app code, actual values indicate logic bug, PR changed production files.
   Choose "infrastructure" when: logs show ECONNREFUSED, missing tables, empty DB, failed migrations, many unrelated tests fail similarly.
   Priority: infrastructure → production → test → unknown (smallest scope that explains the failure).
 

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -141,14 +141,39 @@ When calling the "done" tool, classify your conclusion:
 For "diagnosis" category, provide structured Root Cause Analysis:
   - title: Short summary (e.g., "Timeout waiting for Submit Button")
   - failure_type: One of: timeout, assertion, network, infra, flake
-  - file_path: Test file where failure occurred (e.g., "tests/checkout.spec.ts")
+  - file_path: Test file where failure occurred
   - line_number: Line number in the test file (if known)
+  - bug_location: Where the underlying defect lives (REQUIRED)
+  - bug_location_confidence: How confident you are in bug_location (REQUIRED)
+  - bug_code_file_path: Suspected defect file (when bug_location is production/infrastructure)
+  - bug_code_line_number: Line in suspected defect file
   - symptom: What failed (the observable error)
   - root_cause: Why it failed (the underlying issue)
-  - evidence: Array of supporting data points, each with type (screenshot/trace/log/network/code) and content
+  - evidence: Array of supporting data points
   - remediation: How to fix it (actionable guidance)
   - confidence: 0-100 score
   - missing_information_sensitivity: high/medium/low
+
+Bug location classification:
+  Do NOT assume every assertion failure is a test bug. Determine WHERE the defect lives:
+  - "test": Bug in test code, fixtures, test data, or mocks
+  - "production": Test correctly detected a regression in application code
+  - "infrastructure": CI environment, database, network, or config issue
+  - "unknown": Not enough evidence — use this instead of guessing
+
+  Choose "test" when: stack trace is entirely in test files, expected value is outdated, assertion is brittle.
+  Choose "production" when: stack trace shows exception in app code, actual values indicate logic bug, test passes on main but fails in PR.
+  Choose "infrastructure" when: logs show ECONNREFUSED, missing tables, empty DB, failed migrations, many unrelated tests fail similarly.
+  Priority: infrastructure → production → test → unknown (smallest scope that explains the failure).
+
+  Set bug_location_confidence:
+  - "high": Clear stack trace + file evidence
+  - "medium": Probable but some ambiguity
+  - "low": Mostly guessing — prefer "unknown" over low-confidence guesses
+
+  Example A (test bug): expect(price).toBe("$10.00") fails because business logic changed but test wasn't updated → bug_location="test"
+  Example B (production bug): pricing.ts returns "$0.00" for valid inputs, stack trace in src/pricing.ts:42 → bug_location="production", bug_code_file_path="src/pricing.ts"
+  Example C (infrastructure): DB empty in CI, queries return no rows → bug_location="infrastructure"
 
 Confidence scoring (0-100):
   - 80-100: Clear root cause identified with strong evidence

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -264,6 +264,10 @@ var geminiDoneCall = GenerateResponse{
 				"root_cause":                      "A likely regression in Playwright's WebKit support for macOS was introduced by a dependency update. This is causing fundamental browser operations (launching, closing, and crash event handling) to time out, leading to test failures across multiple suites.",
 				"evidence":                        []any{map[string]any{"type": "log", "content": "Error: page.on('crash') did not fire"}, map[string]any{"type": "log", "content": "Test timeout of 30000ms exceeded."}, map[string]any{"type": "log", "content": "browserType.launchPersistentContext failed: Timeout exceeded"}},
 				"remediation":                     "The dependency updates in commit f4923837 should be investigated as the likely source of this regression. The team should identify the specific dependency causing the issue and consider reverting it or upgrading to a patched version.",
+				"bug_location":                    "production",
+				"bug_location_confidence":         "medium",
+				"bug_code_file_path":              "packages/playwright-core/src/server/webkit/wkBrowser.ts",
+				"bug_code_line_number":            float64(87),
 			},
 		},
 	}}}}},
@@ -283,6 +287,11 @@ func TestGeminiDoneFixture_ParsesRCA(t *testing.T) {
 	assert.Len(t, rca.Evidence, 3)
 	assert.Contains(t, rca.RootCause, "regression")
 	assert.Contains(t, rca.Remediation, "f4923837")
+	assert.Equal(t, BugLocationProduction, rca.BugLocation)
+	assert.Equal(t, "medium", rca.BugLocationConfidence)
+	require.NotNil(t, rca.BugCodeLocation)
+	assert.Contains(t, rca.BugCodeLocation.FilePath, "wkBrowser.ts")
+	assert.Equal(t, 87, rca.BugCodeLocation.LineNumber)
 }
 
 func TestGenerate_RetriesOn429(t *testing.T) {

--- a/pkg/llm/rca.go
+++ b/pkg/llm/rca.go
@@ -14,6 +14,16 @@ const (
 	FailureTypeFlake     = "flake"
 )
 
+// BugLocation indicates where the underlying defect lives.
+type BugLocation string
+
+const (
+	BugLocationTest           BugLocation = "test"
+	BugLocationProduction     BugLocation = "production"
+	BugLocationInfrastructure BugLocation = "infrastructure"
+	BugLocationUnknown        BugLocation = "unknown"
+)
+
 // Evidence type constants for categorizing supporting data.
 const (
 	EvidenceScreenshot = "screenshot"
@@ -25,13 +35,16 @@ const (
 
 // RootCauseAnalysis holds structured diagnosis information.
 type RootCauseAnalysis struct {
-	Title       string        `json:"title"`              // Short summary, e.g. "Timeout waiting for Submit Button"
-	FailureType string        `json:"failure_type"`       // timeout, assertion, network, infra, flake
-	Location    *CodeLocation `json:"location,omitempty"` // Where the failure occurred
-	Symptom     string        `json:"symptom"`            // What failed
-	RootCause   string        `json:"root_cause"`         // Why it failed
-	Evidence    []Evidence    `json:"evidence"`           // Supporting data points
-	Remediation string        `json:"remediation"`        // How to fix it
+	Title                 string        `json:"title"`                             // Short summary
+	FailureType           string        `json:"failure_type"`                      // timeout, assertion, network, infra, flake
+	Location              *CodeLocation `json:"location,omitempty"`                // Where the test failed
+	BugLocation           BugLocation   `json:"bug_location,omitempty"`            // Where the defect lives: test, production, infrastructure, unknown
+	BugLocationConfidence string        `json:"bug_location_confidence,omitempty"` // high, medium, low
+	BugCodeLocation       *CodeLocation `json:"bug_code_location,omitempty"`       // Suspected defect location (production/infra code)
+	Symptom               string        `json:"symptom"`                           // What failed
+	RootCause             string        `json:"root_cause"`                        // Why it failed
+	Evidence              []Evidence    `json:"evidence"`                          // Supporting data points
+	Remediation           string        `json:"remediation"`                       // How to fix it
 }
 
 // CodeLocation identifies a specific location in source code.
@@ -54,19 +67,29 @@ func ParseRCAFromArgs(args map[string]any) *RootCauseAnalysis {
 	}
 
 	rca := &RootCauseAnalysis{
-		Title:       stringArg(args, "title"),
-		FailureType: stringArg(args, "failure_type"),
-		Symptom:     stringArg(args, "symptom"),
-		RootCause:   stringArg(args, "root_cause"),
-		Remediation: stringArg(args, "remediation"),
+		Title:                 stringArg(args, "title"),
+		FailureType:           stringArg(args, "failure_type"),
+		BugLocation:           BugLocation(stringArg(args, "bug_location")),
+		BugLocationConfidence: stringArg(args, "bug_location_confidence"),
+		Symptom:               stringArg(args, "symptom"),
+		RootCause:             stringArg(args, "root_cause"),
+		Remediation:           stringArg(args, "remediation"),
 	}
 
-	// Parse location if file_path is present
+	// Parse test failure location
 	if filePath := stringArg(args, "file_path"); filePath != "" {
 		rca.Location = &CodeLocation{
 			FilePath:     filePath,
 			LineNumber:   intArgValue(args, "line_number"),
 			FunctionName: stringArg(args, "function_name"),
+		}
+	}
+
+	// Parse suspected bug code location (flat args, same pattern)
+	if filePath := stringArg(args, "bug_code_file_path"); filePath != "" {
+		rca.BugCodeLocation = &CodeLocation{
+			FilePath:   filePath,
+			LineNumber: intArgValue(args, "bug_code_line_number"),
 		}
 	}
 

--- a/pkg/llm/rca_test.go
+++ b/pkg/llm/rca_test.go
@@ -181,6 +181,53 @@ func TestAnalysisResult_WithoutRCA_LegacyText(t *testing.T) {
 	assert.Nil(t, decoded.RCA)
 }
 
+func TestBugLocation_Constants(t *testing.T) {
+	assert.Equal(t, BugLocation("test"), BugLocationTest)
+	assert.Equal(t, BugLocation("production"), BugLocationProduction)
+	assert.Equal(t, BugLocation("infrastructure"), BugLocationInfrastructure)
+	assert.Equal(t, BugLocation("unknown"), BugLocationUnknown)
+}
+
+func TestParseRCAFromArgs_WithBugLocation(t *testing.T) {
+	args := map[string]any{
+		"title":                   "Price calculation broken",
+		"failure_type":            "assertion",
+		"file_path":               "tests/checkout.spec.ts",
+		"line_number":             float64(45),
+		"bug_location":            "production",
+		"bug_location_confidence": "high",
+		"bug_code_file_path":      "src/pricing.ts",
+		"bug_code_line_number":    float64(42),
+		"symptom":                 "Expected $10.00, got $0.00",
+		"root_cause":              "Pricing function returns zero",
+		"remediation":             "Fix calculatePrice() in pricing.ts",
+	}
+
+	rca := ParseRCAFromArgs(args)
+
+	assert.Equal(t, BugLocationProduction, rca.BugLocation)
+	assert.Equal(t, "high", rca.BugLocationConfidence)
+	require.NotNil(t, rca.BugCodeLocation)
+	assert.Equal(t, "src/pricing.ts", rca.BugCodeLocation.FilePath)
+	assert.Equal(t, 42, rca.BugCodeLocation.LineNumber)
+}
+
+func TestParseRCAFromArgs_DefaultBugLocation(t *testing.T) {
+	args := map[string]any{
+		"title":        "Error",
+		"failure_type": "timeout",
+		"symptom":      "Timed out",
+		"root_cause":   "Slow",
+		"remediation":  "Fix",
+	}
+
+	rca := ParseRCAFromArgs(args)
+
+	assert.Equal(t, BugLocation(""), rca.BugLocation)
+	assert.Equal(t, "", rca.BugLocationConfidence)
+	assert.Nil(t, rca.BugCodeLocation)
+}
+
 func TestFailureType_Constants(t *testing.T) {
 	// Verify all failure type constants are defined
 	assert.Equal(t, "timeout", FailureTypeTimeout)


### PR DESCRIPTION
## Summary

Adds orthogonal `bug_location` axis to Root Cause Analysis, enabling heisenberg to distinguish **where the defect lives** — in test code, production code, or infrastructure — separately from how the failure manifested (`failure_type`).

- **`bug_location`** (required): `test` | `production` | `infrastructure` | `unknown`
- **`bug_location_confidence`**: `high` | `medium` | `low`
- **`bug_code_file_path`** + **`bug_code_line_number`**: suspected production/infra defect location

CLI shows `[production bug]` or `[production bug?]` tags based on confidence. No tag for `test`/`unknown` (default assumption).

Validated by Perplexity Research (IBM Orthogonal Defect Classification + Currents tool) and Zen code review (Gemini 2.5 Pro + 3 Pro).

**V1 (this PR):** bug_location + prompt heuristics, using existing tools only.
**V2 (future):** Add `get_pr_diff` tool for git diff context.

Closes #20

## Test plan

- [x] `go test -race ./...` — all pass
- [x] New tests: `TestBugLocation_Constants`, `TestParseRCAFromArgs_WithBugLocation`, `TestParseRCAFromArgs_DefaultBugLocation`
- [x] CLI tests: `TestPrintStructuredRCA_ProductionBug_HighConfidence`, `_LowConfidence`, `_TestBug_NoTag`, `_InfraBug`, `_UnknownBugLocation`
- [x] Updated `geminiDoneCall` fixture with bug_location fields
- [ ] CI green
- [ ] Manual E2E: run against microsoft/playwright, verify bug_location populated