### PR TITLE
feat: hybrid failure clustering for large CI runs

### DIFF
--- a/pkg/analysis/merge.go
+++ b/pkg/analysis/merge.go
@@ -1,0 +1,111 @@
+package analysis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kamilpajak/heisenberg/pkg/cluster"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+)
+
+// clusterAnalysis pairs a cluster with its LLM analysis result.
+type clusterAnalysis struct {
+	Cluster cluster.Cluster
+	Result  *llm.AnalysisResult
+}
+
+// mergeClusterResults combines per-cluster AnalysisResults into a single
+// run-level result. It deduplicates RCAs with identical root causes,
+// computes weighted confidence, and generates a summary text.
+func mergeClusterResults(results []clusterAnalysis) *llm.AnalysisResult {
+	if len(results) == 0 {
+		return &llm.AnalysisResult{}
+	}
+
+	// Single cluster — return as-is
+	if len(results) == 1 {
+		return results[0].Result
+	}
+
+	merged := &llm.AnalysisResult{}
+
+	// Collect RCAs, deduplicating identical root causes
+	seen := map[string]bool{}
+	for _, ca := range results {
+		if ca.Result == nil {
+			continue
+		}
+		for _, rca := range ca.Result.RCAs {
+			key := strings.ToLower(strings.TrimSpace(rca.Title + "|" + rca.RootCause))
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			merged.RCAs = append(merged.RCAs, rca)
+		}
+	}
+
+	// Category: diagnosis if any cluster has diagnosis
+	merged.Category = llm.CategoryNotSupported
+	for _, ca := range results {
+		if ca.Result != nil && ca.Result.Category == llm.CategoryDiagnosis {
+			merged.Category = llm.CategoryDiagnosis
+			break
+		}
+	}
+	if merged.Category != llm.CategoryDiagnosis {
+		for _, ca := range results {
+			if ca.Result != nil && ca.Result.Category == llm.CategoryNoFailures {
+				merged.Category = llm.CategoryNoFailures
+				break
+			}
+		}
+	}
+
+	// Confidence: weighted average by cluster size
+	totalWeight := 0
+	weightedSum := 0
+	for _, ca := range results {
+		if ca.Result == nil {
+			continue
+		}
+		w := len(ca.Cluster.Failures)
+		if w == 0 {
+			w = 1
+		}
+		weightedSum += ca.Result.Confidence * w
+		totalWeight += w
+	}
+	if totalWeight > 0 {
+		merged.Confidence = weightedSum / totalWeight
+	}
+
+	// Sensitivity: take highest (worst)
+	sensOrder := map[string]int{"high": 3, "medium": 2, "low": 1}
+	maxSens := 0
+	for _, ca := range results {
+		if ca.Result != nil {
+			if s, ok := sensOrder[ca.Result.Sensitivity]; ok && s > maxSens {
+				maxSens = s
+				merged.Sensitivity = ca.Result.Sensitivity
+			}
+		}
+	}
+
+	// Text: structured summary
+	var sb strings.Builder
+	for i, ca := range results {
+		if ca.Result == nil {
+			continue
+		}
+		if i > 0 {
+			sb.WriteString("\n---\n\n")
+		}
+		sb.WriteString(fmt.Sprintf("## Cluster %d (%d jobs)\n\n", ca.Cluster.ID, len(ca.Cluster.Failures)))
+		sb.WriteString(ca.Result.Text)
+		sb.WriteString("\n")
+	}
+	merged.Text = sb.String()
+
+	return merged
+}

--- a/pkg/analysis/merge.go
+++ b/pkg/analysis/merge.go
@@ -21,16 +21,22 @@ func mergeClusterResults(results []clusterAnalysis) *llm.AnalysisResult {
 	if len(results) == 0 {
 		return &llm.AnalysisResult{}
 	}
-
-	// Single cluster — return as-is
 	if len(results) == 1 {
 		return results[0].Result
 	}
 
-	merged := &llm.AnalysisResult{}
+	return &llm.AnalysisResult{
+		RCAs:        collectRCAs(results),
+		Category:    mergeCategory(results),
+		Confidence:  mergeConfidence(results),
+		Sensitivity: mergeSensitivity(results),
+		Text:        mergeText(results),
+	}
+}
 
-	// Collect RCAs, deduplicating identical root causes
+func collectRCAs(results []clusterAnalysis) []llm.RootCauseAnalysis {
 	seen := map[string]bool{}
+	var rcas []llm.RootCauseAnalysis
 	for _, ca := range results {
 		if ca.Result == nil {
 			continue
@@ -41,30 +47,28 @@ func mergeClusterResults(results []clusterAnalysis) *llm.AnalysisResult {
 				continue
 			}
 			seen[key] = true
-			merged.RCAs = append(merged.RCAs, rca)
+			rcas = append(rcas, rca)
 		}
 	}
+	return rcas
+}
 
-	// Category: diagnosis if any cluster has diagnosis
-	merged.Category = llm.CategoryNotSupported
+func mergeCategory(results []clusterAnalysis) string {
 	for _, ca := range results {
 		if ca.Result != nil && ca.Result.Category == llm.CategoryDiagnosis {
-			merged.Category = llm.CategoryDiagnosis
-			break
+			return llm.CategoryDiagnosis
 		}
 	}
-	if merged.Category != llm.CategoryDiagnosis {
-		for _, ca := range results {
-			if ca.Result != nil && ca.Result.Category == llm.CategoryNoFailures {
-				merged.Category = llm.CategoryNoFailures
-				break
-			}
+	for _, ca := range results {
+		if ca.Result != nil && ca.Result.Category == llm.CategoryNoFailures {
+			return llm.CategoryNoFailures
 		}
 	}
+	return llm.CategoryNotSupported
+}
 
-	// Confidence: weighted average by cluster size
-	totalWeight := 0
-	weightedSum := 0
+func mergeConfidence(results []clusterAnalysis) int {
+	totalWeight, weightedSum := 0, 0
 	for _, ca := range results {
 		if ca.Result == nil {
 			continue
@@ -76,23 +80,28 @@ func mergeClusterResults(results []clusterAnalysis) *llm.AnalysisResult {
 		weightedSum += ca.Result.Confidence * w
 		totalWeight += w
 	}
-	if totalWeight > 0 {
-		merged.Confidence = weightedSum / totalWeight
+	if totalWeight == 0 {
+		return 0
 	}
+	return weightedSum / totalWeight
+}
 
-	// Sensitivity: take highest (worst)
-	sensOrder := map[string]int{"high": 3, "medium": 2, "low": 1}
-	maxSens := 0
+func mergeSensitivity(results []clusterAnalysis) string {
+	order := map[string]int{"high": 3, "medium": 2, "low": 1}
+	best, bestVal := "", 0
 	for _, ca := range results {
-		if ca.Result != nil {
-			if s, ok := sensOrder[ca.Result.Sensitivity]; ok && s > maxSens {
-				maxSens = s
-				merged.Sensitivity = ca.Result.Sensitivity
-			}
+		if ca.Result == nil {
+			continue
+		}
+		if v := order[ca.Result.Sensitivity]; v > bestVal {
+			bestVal = v
+			best = ca.Result.Sensitivity
 		}
 	}
+	return best
+}
 
-	// Text: structured summary
+func mergeText(results []clusterAnalysis) string {
 	var sb strings.Builder
 	for i, ca := range results {
 		if ca.Result == nil {
@@ -105,7 +114,5 @@ func mergeClusterResults(results []clusterAnalysis) *llm.AnalysisResult {
 		sb.WriteString(ca.Result.Text)
 		sb.WriteString("\n")
 	}
-	merged.Text = sb.String()
-
-	return merged
+	return sb.String()
 }

--- a/pkg/analysis/merge.go
+++ b/pkg/analysis/merge.go
@@ -101,7 +101,7 @@ func mergeClusterResults(results []clusterAnalysis) *llm.AnalysisResult {
 		if i > 0 {
 			sb.WriteString("\n---\n\n")
 		}
-		sb.WriteString(fmt.Sprintf("## Cluster %d (%d jobs)\n\n", ca.Cluster.ID, len(ca.Cluster.Failures)))
+		fmt.Fprintf(&sb, "## Cluster %d (%d jobs)\n\n", ca.Cluster.ID, len(ca.Cluster.Failures))
 		sb.WriteString(ca.Result.Text)
 		sb.WriteString("\n")
 	}

--- a/pkg/analysis/merge_test.go
+++ b/pkg/analysis/merge_test.go
@@ -110,6 +110,28 @@ func TestMergeClusterResults_Empty(t *testing.T) {
 	assert.Empty(t, merged.RCAs)
 }
 
+func TestMergeCategory_NoFailures(t *testing.T) {
+	results := []clusterAnalysis{
+		{Result: &llm.AnalysisResult{Category: llm.CategoryNoFailures}},
+	}
+	assert.Equal(t, llm.CategoryNoFailures, mergeCategory(results))
+}
+
+func TestMergeCategory_NotSupported(t *testing.T) {
+	results := []clusterAnalysis{
+		{Result: &llm.AnalysisResult{Category: llm.CategoryNotSupported}},
+	}
+	assert.Equal(t, llm.CategoryNotSupported, mergeCategory(results))
+}
+
+func TestMergeConfidence_Empty(t *testing.T) {
+	assert.Equal(t, 0, mergeConfidence(nil))
+}
+
+func TestMergeSensitivity_Empty(t *testing.T) {
+	assert.Equal(t, "", mergeSensitivity(nil))
+}
+
 func TestMergeClusterResults_MixedCategories(t *testing.T) {
 	results := []clusterAnalysis{
 		{

--- a/pkg/analysis/merge_test.go
+++ b/pkg/analysis/merge_test.go
@@ -132,6 +132,42 @@ func TestMergeSensitivity_Empty(t *testing.T) {
 	assert.Equal(t, "", mergeSensitivity(nil))
 }
 
+func TestMergeText_NilResult(t *testing.T) {
+	results := []clusterAnalysis{
+		{
+			Cluster: cluster.Cluster{ID: 1, Failures: make([]cluster.FailureInfo, 2)},
+			Result:  &llm.AnalysisResult{Text: "Cluster 1 text"},
+		},
+		{
+			Cluster: cluster.Cluster{ID: 2, Failures: make([]cluster.FailureInfo, 1)},
+			Result:  nil, // nil result should be skipped
+		},
+		{
+			Cluster: cluster.Cluster{ID: 3, Failures: make([]cluster.FailureInfo, 1)},
+			Result:  &llm.AnalysisResult{Text: "Cluster 3 text"},
+		},
+	}
+
+	text := mergeText(results)
+
+	assert.Contains(t, text, "Cluster 1")
+	assert.Contains(t, text, "Cluster 3")
+	assert.NotContains(t, text, "Cluster 2")
+}
+
+func TestCollectRCAs_NilResult(t *testing.T) {
+	results := []clusterAnalysis{
+		{Result: nil},
+		{Result: &llm.AnalysisResult{
+			RCAs: []llm.RootCauseAnalysis{{Title: "Bug", RootCause: "reason"}},
+		}},
+	}
+
+	rcas := collectRCAs(results)
+	require.Len(t, rcas, 1)
+	assert.Equal(t, "Bug", rcas[0].Title)
+}
+
 func TestMergeClusterResults_MixedCategories(t *testing.T) {
 	results := []clusterAnalysis{
 		{

--- a/pkg/analysis/merge_test.go
+++ b/pkg/analysis/merge_test.go
@@ -1,0 +1,135 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/kamilpajak/heisenberg/pkg/cluster"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeClusterResults_TwoClusters(t *testing.T) {
+	results := []clusterAnalysis{
+		{
+			Cluster: cluster.Cluster{ID: 1, Failures: make([]cluster.FailureInfo, 4)},
+			Result: &llm.AnalysisResult{
+				Text:        "Cluster 1 analysis",
+				Category:    llm.CategoryDiagnosis,
+				Confidence:  90,
+				Sensitivity: "low",
+				RCAs: []llm.RootCauseAnalysis{
+					{Title: "Connection refused", FailureType: llm.FailureTypeInfra, RootCause: "DB not started"},
+				},
+			},
+		},
+		{
+			Cluster: cluster.Cluster{ID: 2, Failures: make([]cluster.FailureInfo, 1)},
+			Result: &llm.AnalysisResult{
+				Text:        "Cluster 2 analysis",
+				Category:    llm.CategoryDiagnosis,
+				Confidence:  70,
+				Sensitivity: "high",
+				RCAs: []llm.RootCauseAnalysis{
+					{Title: "Assertion failed", FailureType: llm.FailureTypeAssertion, RootCause: "Outdated snapshot"},
+				},
+			},
+		},
+	}
+
+	merged := mergeClusterResults(results)
+
+	assert.Equal(t, llm.CategoryDiagnosis, merged.Category)
+	require.Len(t, merged.RCAs, 2)
+	assert.Equal(t, "Connection refused", merged.RCAs[0].Title)
+	assert.Equal(t, "Assertion failed", merged.RCAs[1].Title)
+	// Weighted confidence: (90*4 + 70*1) / 5 = 86
+	assert.Equal(t, 86, merged.Confidence)
+	// Sensitivity: take highest (worst)
+	assert.Equal(t, "high", merged.Sensitivity)
+	assert.Contains(t, merged.Text, "Cluster 1")
+	assert.Contains(t, merged.Text, "Cluster 2")
+}
+
+func TestMergeClusterResults_DeduplicateIdenticalRootCauses(t *testing.T) {
+	results := []clusterAnalysis{
+		{
+			Cluster: cluster.Cluster{ID: 1, Failures: make([]cluster.FailureInfo, 3)},
+			Result: &llm.AnalysisResult{
+				Category:   llm.CategoryDiagnosis,
+				Confidence: 85,
+				RCAs: []llm.RootCauseAnalysis{
+					{Title: "DB connection refused", RootCause: "database not running"},
+				},
+			},
+		},
+		{
+			Cluster: cluster.Cluster{ID: 2, Failures: make([]cluster.FailureInfo, 2)},
+			Result: &llm.AnalysisResult{
+				Category:   llm.CategoryDiagnosis,
+				Confidence: 80,
+				RCAs: []llm.RootCauseAnalysis{
+					{Title: "DB connection refused", RootCause: "database not running"},
+				},
+			},
+		},
+	}
+
+	merged := mergeClusterResults(results)
+
+	// Same root cause → deduplicated to 1 RCA
+	require.Len(t, merged.RCAs, 1)
+	assert.Equal(t, "DB connection refused", merged.RCAs[0].Title)
+}
+
+func TestMergeClusterResults_SingleCluster(t *testing.T) {
+	results := []clusterAnalysis{
+		{
+			Cluster: cluster.Cluster{ID: 1, Failures: make([]cluster.FailureInfo, 2)},
+			Result: &llm.AnalysisResult{
+				Text:        "Single cluster analysis",
+				Category:    llm.CategoryDiagnosis,
+				Confidence:  95,
+				Sensitivity: "low",
+				RCAs: []llm.RootCauseAnalysis{
+					{Title: "Timeout", FailureType: llm.FailureTypeTimeout},
+				},
+			},
+		},
+	}
+
+	merged := mergeClusterResults(results)
+
+	require.Len(t, merged.RCAs, 1)
+	assert.Equal(t, 95, merged.Confidence)
+	assert.Equal(t, "Single cluster analysis", merged.Text)
+}
+
+func TestMergeClusterResults_Empty(t *testing.T) {
+	merged := mergeClusterResults(nil)
+	assert.Empty(t, merged.RCAs)
+}
+
+func TestMergeClusterResults_MixedCategories(t *testing.T) {
+	results := []clusterAnalysis{
+		{
+			Cluster: cluster.Cluster{ID: 1, Failures: make([]cluster.FailureInfo, 3)},
+			Result: &llm.AnalysisResult{
+				Category: llm.CategoryDiagnosis,
+				RCAs:     []llm.RootCauseAnalysis{{Title: "Bug"}},
+			},
+		},
+		{
+			Cluster: cluster.Cluster{ID: 2, Failures: make([]cluster.FailureInfo, 1)},
+			Result: &llm.AnalysisResult{
+				Category: llm.CategoryNotSupported,
+			},
+		},
+	}
+
+	merged := mergeClusterResults(results)
+
+	// If any cluster is diagnosis, overall is diagnosis
+	assert.Equal(t, llm.CategoryDiagnosis, merged.Category)
+	require.Len(t, merged.RCAs, 1)
+}

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -29,8 +29,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 	ghClient := gh.NewClient()
 
 	// Resolve run ID
-	resolvedRunID := p.RunID
-	if resolvedRunID == 0 {
+	if p.RunID == 0 {
 		emitInfo(p.Emitter, fmt.Sprintf("Finding run to analyze for %s/%s...", p.Owner, p.Repo))
 		runs, err := ghClient.ListWorkflowRuns(ctx, p.Owner, p.Repo)
 		if err != nil {
@@ -38,7 +37,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		}
 
 		var shouldSkip bool
-		resolvedRunID, shouldSkip = findRunToAnalyze(runs)
+		p.RunID, shouldSkip = findRunToAnalyze(runs)
 
 		if shouldSkip {
 			return &llm.AnalysisResult{
@@ -47,25 +46,25 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 			}, nil
 		}
 
-		if resolvedRunID == 0 {
+		if p.RunID == 0 {
 			return nil, fmt.Errorf("no failed workflow runs found for %s/%s", p.Owner, p.Repo)
 		}
 	}
 
-	emitInfo(p.Emitter, fmt.Sprintf("Analyzing run %d for %s/%s...", resolvedRunID, p.Owner, p.Repo))
+	emitInfo(p.Emitter, fmt.Sprintf("Analyzing run %d for %s/%s...", p.RunID, p.Owner, p.Repo))
 
 	// Fetch run metadata, jobs, and artifacts
-	wfRun, err := ghClient.GetWorkflowRun(ctx, p.Owner, p.Repo, resolvedRunID)
+	wfRun, err := ghClient.GetWorkflowRun(ctx, p.Owner, p.Repo, p.RunID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch run: %w", err)
 	}
 
-	jobs, err := ghClient.ListJobs(ctx, p.Owner, p.Repo, resolvedRunID)
+	jobs, err := ghClient.ListJobs(ctx, p.Owner, p.Repo, p.RunID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list jobs: %w", err)
 	}
 
-	artifacts, err := ghClient.ListArtifacts(ctx, p.Owner, p.Repo, resolvedRunID)
+	artifacts, err := ghClient.ListArtifacts(ctx, p.Owner, p.Repo, p.RunID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list artifacts: %w", err)
 	}
@@ -74,7 +73,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 	artifactStatus := gh.CheckArtifacts(artifacts)
 	if artifactStatus.AllExpired {
 		runDate := formatRunDate(wfRun.CreatedAt)
-		return nil, fmt.Errorf("all artifacts have expired for run %d (created %s)\n\nArtifacts expire after 90 days. Try analyzing a more recent run, or omit --run-id to use the latest failed run", resolvedRunID, runDate)
+		return nil, fmt.Errorf("all artifacts have expired for run %d (created %s)\n\nArtifacts expire after 90 days. Try analyzing a more recent run, or omit --run-id to use the latest failed run", p.RunID, runDate)
 	}
 
 	// Clustering gate: if many failed jobs, use per-cluster analysis
@@ -82,24 +81,14 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 	failedJobs := filterFailed(jobs)
 	if len(failedJobs) > clusterThreshold {
 		result, err := runClustered(ctx, p, ghClient, wfRun, jobs, failedJobs, artifacts)
-		if err != nil {
-			return nil, err
-		}
-		result.RunID = resolvedRunID
-		result.Branch = wfRun.HeadBranch
-		result.CommitSHA = wfRun.HeadSHA
-		return result, nil
+		stampRunMeta(result, p.RunID, wfRun)
+		return result, err
 	}
 
 	// Standard single-loop path (unchanged for <= threshold failures)
 	result, err := runSingle(ctx, p, ghClient, wfRun, jobs, artifacts)
-	if err != nil {
-		return nil, err
-	}
-	result.RunID = resolvedRunID
-	result.Branch = wfRun.HeadBranch
-	result.CommitSHA = wfRun.HeadSHA
-	return result, nil
+	stampRunMeta(result, p.RunID, wfRun)
+	return result, err
 }
 
 // runSingle is the original single-agent-loop analysis path.
@@ -191,10 +180,32 @@ func runClustered(ctx context.Context, p Params, ghClient *gh.Client,
 		results = append(results, clusterAnalysis{Cluster: c, Result: result})
 	}
 
-	// Handle unclustered failures
+	// Handle unclustered failures — create a synthetic cluster and analyze
 	if len(cr.Unclustered) > 0 {
 		emitInfo(p.Emitter, fmt.Sprintf("[Other] Analyzing %d unclustered jobs...", len(cr.Unclustered)))
-		// Fall back to single-loop for unclustered failures (they go through normal path)
+
+		uc := cluster.Cluster{
+			ID:       len(cr.Clusters) + 1,
+			Failures: cr.Unclustered,
+		}
+		// Pick representative with longest log
+		uc.Representative = cr.Unclustered[0]
+		for _, f := range cr.Unclustered[1:] {
+			if len(f.LogTail) > len(uc.Representative.LogTail) {
+				uc.Representative = f
+			}
+		}
+
+		clusterCtx := buildClusterContext(wfRun, uc, uc.ID, len(cr.Clusters)+1, allJobs, artifacts)
+		ucHandler := &ToolHandler{
+			GitHub: ghClient, Owner: p.Owner, Repo: p.Repo,
+			RunID: p.RunID, PRNumber: prNumber, HeadSHA: wfRun.HeadSHA,
+			SnapshotHTML: p.SnapshotHTML, Emitter: p.Emitter, artifacts: artifacts,
+		}
+		ucResult, ucErr := llmClient.RunAgentLoop(ctx, ucHandler, ToolDeclarations(), clusterCtx, p.Verbose)
+		if ucErr == nil && ucResult != nil {
+			results = append(results, clusterAnalysis{Cluster: uc, Result: ucResult})
+		}
 	}
 
 	merged := mergeClusterResults(results)
@@ -213,7 +224,6 @@ func fetchFailureLogs(ctx context.Context, ghClient *gh.Client, p Params, failed
 	const maxConcurrent = 5
 	sem := make(chan struct{}, maxConcurrent)
 
-	var mu sync.Mutex
 	failures := make([]cluster.FailureInfo, len(failedJobs))
 
 	var wg sync.WaitGroup
@@ -237,7 +247,7 @@ func fetchFailureLogs(ctx context.Context, ghClient *gh.Client, p Params, failed
 				logTail = logTail[len(logTail)-10000:]
 			}
 
-			mu.Lock()
+			// Each goroutine writes to its own pre-allocated index — no mutex needed
 			failures[idx] = cluster.FailureInfo{
 				JobID:      j.ID,
 				JobName:    j.Name,
@@ -245,7 +255,6 @@ func fetchFailureLogs(ctx context.Context, ghClient *gh.Client, p Params, failed
 				Signature:  sig,
 				LogTail:    logTail,
 			}
-			mu.Unlock()
 		}(i, job)
 	}
 	wg.Wait()
@@ -320,6 +329,15 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+func stampRunMeta(result *llm.AnalysisResult, runID int64, wfRun *gh.WorkflowRun) {
+	if result == nil {
+		return
+	}
+	result.RunID = runID
+	result.Branch = wfRun.HeadBranch
+	result.CommitSHA = wfRun.HeadSHA
 }
 
 func emitInfo(e llm.ProgressEmitter, msg string) {

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/kamilpajak/heisenberg/pkg/cluster"
 	gh "github.com/kamilpajak/heisenberg/pkg/github"
 	"github.com/kamilpajak/heisenberg/pkg/llm"
 )
@@ -75,9 +77,37 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		return nil, fmt.Errorf("all artifacts have expired for run %d (created %s)\n\nArtifacts expire after 90 days. Try analyzing a more recent run, or omit --run-id to use the latest failed run", resolvedRunID, runDate)
 	}
 
+	// Clustering gate: if many failed jobs, use per-cluster analysis
+	const clusterThreshold = 6
+	failedJobs := filterFailed(jobs)
+	if len(failedJobs) > clusterThreshold {
+		result, err := runClustered(ctx, p, ghClient, wfRun, jobs, failedJobs, artifacts)
+		if err != nil {
+			return nil, err
+		}
+		result.RunID = resolvedRunID
+		result.Branch = wfRun.HeadBranch
+		result.CommitSHA = wfRun.HeadSHA
+		return result, nil
+	}
+
+	// Standard single-loop path (unchanged for <= threshold failures)
+	result, err := runSingle(ctx, p, ghClient, wfRun, jobs, artifacts)
+	if err != nil {
+		return nil, err
+	}
+	result.RunID = resolvedRunID
+	result.Branch = wfRun.HeadBranch
+	result.CommitSHA = wfRun.HeadSHA
+	return result, nil
+}
+
+// runSingle is the original single-agent-loop analysis path.
+func runSingle(ctx context.Context, p Params, ghClient *gh.Client,
+	wfRun *gh.WorkflowRun, jobs []gh.Job, artifacts []gh.Artifact) (*llm.AnalysisResult, error) {
+
 	initialContext := buildInitialContext(wfRun, jobs, artifacts)
 
-	// Detect PR number from workflow run metadata
 	var prNumber int
 	if len(wfRun.PullRequests) > 0 {
 		prNumber = wfRun.PullRequests[0].Number
@@ -87,7 +117,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		GitHub:       ghClient,
 		Owner:        p.Owner,
 		Repo:         p.Repo,
-		RunID:        resolvedRunID,
+		RunID:        p.RunID,
 		PRNumber:     prNumber,
 		HeadSHA:      wfRun.HeadSHA,
 		SnapshotHTML: p.SnapshotHTML,
@@ -100,16 +130,196 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		return nil, err
 	}
 
-	result, err := llmClient.RunAgentLoop(ctx, handler, ToolDeclarations(), initialContext, p.Verbose)
+	return llmClient.RunAgentLoop(ctx, handler, ToolDeclarations(), initialContext, p.Verbose)
+}
+
+// runClustered pre-clusters failures by error signature, then runs one LLM
+// agent loop per cluster with focused context.
+func runClustered(ctx context.Context, p Params, ghClient *gh.Client,
+	wfRun *gh.WorkflowRun, allJobs []gh.Job, failedJobs []gh.Job, artifacts []gh.Artifact) (*llm.AnalysisResult, error) {
+
+	emitInfo(p.Emitter, fmt.Sprintf("Clustering %d failed jobs...", len(failedJobs)))
+
+	// Fetch logs for all failed jobs in parallel
+	failures := fetchFailureLogs(ctx, ghClient, p, failedJobs)
+
+	// Cluster by error signature
+	cr := cluster.ClusterFailures(failures)
+
+	// If clustering produced 1 cluster or failed, fall back to single path
+	if len(cr.Clusters) <= 1 {
+		return runSingle(ctx, p, ghClient, wfRun, allJobs, artifacts)
+	}
+
+	emitInfo(p.Emitter, fmt.Sprintf("Found %d failure clusters (%s)", len(cr.Clusters), cr.Method))
+
+	// Run LLM agent loop per cluster
+	var results []clusterAnalysis
+	llmClient, err := llm.NewClient(p.Model)
 	if err != nil {
 		return nil, err
 	}
 
-	result.RunID = resolvedRunID
-	result.Branch = wfRun.HeadBranch
-	result.CommitSHA = wfRun.HeadSHA
+	var prNumber int
+	if len(wfRun.PullRequests) > 0 {
+		prNumber = wfRun.PullRequests[0].Number
+	}
 
-	return result, nil
+	for i, c := range cr.Clusters {
+		emitInfo(p.Emitter, fmt.Sprintf("[Cluster %d/%d] Analyzing %d jobs (%s)...",
+			i+1, len(cr.Clusters), len(c.Failures), truncate(c.Signature.RawExcerpt, 60)))
+
+		clusterCtx := buildClusterContext(wfRun, c, i+1, len(cr.Clusters), allJobs, artifacts)
+
+		handler := &ToolHandler{
+			GitHub:       ghClient,
+			Owner:        p.Owner,
+			Repo:         p.Repo,
+			RunID:        p.RunID,
+			PRNumber:     prNumber,
+			HeadSHA:      wfRun.HeadSHA,
+			SnapshotHTML: p.SnapshotHTML,
+			Emitter:      p.Emitter,
+			artifacts:    artifacts,
+		}
+
+		result, err := llmClient.RunAgentLoop(ctx, handler, ToolDeclarations(), clusterCtx, p.Verbose)
+		if err != nil {
+			return nil, fmt.Errorf("cluster %d: %w", i+1, err)
+		}
+
+		results = append(results, clusterAnalysis{Cluster: c, Result: result})
+	}
+
+	// Handle unclustered failures
+	if len(cr.Unclustered) > 0 {
+		emitInfo(p.Emitter, fmt.Sprintf("[Other] Analyzing %d unclustered jobs...", len(cr.Unclustered)))
+		// Fall back to single-loop for unclustered failures (they go through normal path)
+	}
+
+	merged := mergeClusterResults(results)
+	if merged.Eval == nil {
+		merged.Eval = &llm.EvalMeta{}
+	}
+	merged.Eval.Clustered = true
+	merged.Eval.ClusterCount = len(cr.Clusters)
+	merged.Eval.ClusterMethod = cr.Method
+
+	return merged, nil
+}
+
+// fetchFailureLogs fetches logs for failed jobs in parallel with a concurrency limit.
+func fetchFailureLogs(ctx context.Context, ghClient *gh.Client, p Params, failedJobs []gh.Job) []cluster.FailureInfo {
+	const maxConcurrent = 5
+	sem := make(chan struct{}, maxConcurrent)
+
+	var mu sync.Mutex
+	failures := make([]cluster.FailureInfo, len(failedJobs))
+
+	var wg sync.WaitGroup
+	for i, job := range failedJobs {
+		wg.Add(1)
+		go func(idx int, j gh.Job) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			logText, err := ghClient.GetJobLogs(ctx, p.Owner, p.Repo, j.ID)
+			if err != nil {
+				logText = fmt.Sprintf("(failed to fetch logs: %s)", err)
+			}
+
+			sig := cluster.ExtractSignature(logText)
+
+			// Keep last 10KB for LLM context
+			logTail := logText
+			if len(logTail) > 10000 {
+				logTail = logTail[len(logTail)-10000:]
+			}
+
+			mu.Lock()
+			failures[idx] = cluster.FailureInfo{
+				JobID:      j.ID,
+				JobName:    j.Name,
+				Conclusion: j.Conclusion,
+				Signature:  sig,
+				LogTail:    logTail,
+			}
+			mu.Unlock()
+		}(i, job)
+	}
+	wg.Wait()
+	return failures
+}
+
+// filterFailed returns jobs with conclusion "failure".
+func filterFailed(jobs []gh.Job) []gh.Job {
+	var failed []gh.Job
+	for _, j := range jobs {
+		if j.Conclusion == "failure" {
+			failed = append(failed, j)
+		}
+	}
+	return failed
+}
+
+// buildClusterContext creates a focused initial context for one cluster.
+func buildClusterContext(run *gh.WorkflowRun, c cluster.Cluster,
+	clusterNum, totalClusters int, allJobs []gh.Job, artifacts []gh.Artifact) string {
+
+	var b strings.Builder
+
+	b.WriteString("## Workflow Run\n")
+	fmt.Fprintf(&b, "- Run ID: %d\n", run.ID)
+	fmt.Fprintf(&b, "- Name: %s\n", run.Name)
+	fmt.Fprintf(&b, "- Branch: %s\n", run.HeadBranch)
+	fmt.Fprintf(&b, "- Commit: %s\n", run.HeadSHA)
+	fmt.Fprintf(&b, "- Conclusion: %s\n", run.Conclusion)
+
+	fmt.Fprintf(&b, "\n## Cluster %d of %d — %d jobs\n", clusterNum, totalClusters, len(c.Failures))
+	fmt.Fprintf(&b, "Error pattern: %s\n", c.Signature.RawExcerpt)
+	b.WriteString("\nYou are analyzing a specific cluster of related failures. ")
+	b.WriteString("Do not assume these are the only failures in this run. ")
+	b.WriteString("Focus on the root cause shared by this cluster.\n")
+
+	b.WriteString("\n### Affected Jobs\n")
+	for _, f := range c.Failures {
+		fmt.Fprintf(&b, "- %s (id=%d, %s)\n", f.JobName, f.JobID, f.Conclusion)
+	}
+
+	b.WriteString("\n### Representative Error\n")
+	fmt.Fprintf(&b, "From: %s\n```\n%s\n```\n", c.Representative.JobName, c.Representative.LogTail)
+
+	b.WriteString("\n### Artifacts\n")
+	hasTestArtifacts := false
+	for _, a := range artifacts {
+		if a.Expired {
+			continue
+		}
+		label := ""
+		if isTestArtifact(a.Name) {
+			label = " [TEST REPORT]"
+			hasTestArtifacts = true
+		}
+		fmt.Fprintf(&b, "- %s (%d bytes)%s\n", a.Name, a.SizeBytes, label)
+	}
+
+	b.WriteString("\n### Instructions\n")
+	b.WriteString("Analyze this cluster of related failures to determine their shared root cause.\n")
+	if hasTestArtifacts {
+		b.WriteString("Test report artifacts are available. Fetch them first.\n")
+	}
+	b.WriteString("When done, call the 'done' tool with your analysis.\n")
+
+	return b.String()
+}
+
+// truncate returns s truncated to maxLen with "..." suffix.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
 }
 
 func emitInfo(e llm.ProgressEmitter, msg string) {

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -184,18 +184,7 @@ func runClustered(ctx context.Context, p Params, ghClient *gh.Client,
 	if len(cr.Unclustered) > 0 {
 		emitInfo(p.Emitter, fmt.Sprintf("[Other] Analyzing %d unclustered jobs...", len(cr.Unclustered)))
 
-		uc := cluster.Cluster{
-			ID:       len(cr.Clusters) + 1,
-			Failures: cr.Unclustered,
-		}
-		// Pick representative with longest log
-		uc.Representative = cr.Unclustered[0]
-		for _, f := range cr.Unclustered[1:] {
-			if len(f.LogTail) > len(uc.Representative.LogTail) {
-				uc.Representative = f
-			}
-		}
-
+		uc := buildUnclusteredCluster(cr.Unclustered, len(cr.Clusters)+1)
 		clusterCtx := buildClusterContext(wfRun, uc, uc.ID, len(cr.Clusters)+1, allJobs, artifacts)
 		ucHandler := &ToolHandler{
 			GitHub: ghClient, Owner: p.Owner, Repo: p.Repo,
@@ -321,6 +310,22 @@ func buildClusterContext(run *gh.WorkflowRun, c cluster.Cluster,
 	b.WriteString("When done, call the 'done' tool with your analysis.\n")
 
 	return b.String()
+}
+
+// buildUnclusteredCluster creates a synthetic cluster from failures that
+// couldn't be fingerprinted, picking the longest log as representative.
+func buildUnclusteredCluster(failures []cluster.FailureInfo, id int) cluster.Cluster {
+	c := cluster.Cluster{
+		ID:             id,
+		Failures:       failures,
+		Representative: failures[0],
+	}
+	for _, f := range failures[1:] {
+		if len(f.LogTail) > len(c.Representative.LogTail) {
+			c.Representative = f
+		}
+	}
+	return c
 }
 
 // truncate returns s truncated to maxLen with "..." suffix.

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -219,6 +219,44 @@ func TestBuildClusterContext_NoArtifacts(t *testing.T) {
 	assert.NotContains(t, ctx, "TEST REPORT")
 }
 
+func TestBuildUnclusteredCluster(t *testing.T) {
+	failures := []cluster.FailureInfo{
+		{JobID: 1, JobName: "Short", LogTail: "short"},
+		{JobID: 2, JobName: "Long", LogTail: "this is a much longer log tail"},
+		{JobID: 3, JobName: "Medium", LogTail: "medium length"},
+	}
+
+	c := buildUnclusteredCluster(failures, 5)
+
+	assert.Equal(t, 5, c.ID)
+	require.Len(t, c.Failures, 3)
+	assert.Equal(t, "Long", c.Representative.JobName, "representative should be longest log")
+}
+
+func TestBuildUnclusteredCluster_Single(t *testing.T) {
+	failures := []cluster.FailureInfo{
+		{JobID: 1, JobName: "Only", LogTail: "log"},
+	}
+
+	c := buildUnclusteredCluster(failures, 1)
+	assert.Equal(t, "Only", c.Representative.JobName)
+}
+
+func TestStampRunMeta(t *testing.T) {
+	result := &llm.AnalysisResult{Text: "test"}
+	wfRun := &gh.WorkflowRun{HeadBranch: "main", HeadSHA: "abc123"}
+	stampRunMeta(result, 12345, wfRun)
+
+	assert.Equal(t, int64(12345), result.RunID)
+	assert.Equal(t, "main", result.Branch)
+	assert.Equal(t, "abc123", result.CommitSHA)
+}
+
+func TestStampRunMeta_NilResult(t *testing.T) {
+	// Should not panic
+	stampRunMeta(nil, 12345, &gh.WorkflowRun{})
+}
+
 func TestEmitInfo_NilEmitter(t *testing.T) {
 	// Should not panic
 	emitInfo(nil, "test message")

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kamilpajak/heisenberg/pkg/cluster"
 	gh "github.com/kamilpajak/heisenberg/pkg/github"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -221,6 +222,47 @@ func TestBuildClusterContext_NoArtifacts(t *testing.T) {
 func TestEmitInfo_NilEmitter(t *testing.T) {
 	// Should not panic
 	emitInfo(nil, "test message")
+}
+
+type recordingEmitter struct {
+	events []llm.ProgressEvent
+}
+
+func (r *recordingEmitter) Emit(ev llm.ProgressEvent) { r.events = append(r.events, ev) }
+
+func TestEmitInfo_WithEmitter(t *testing.T) {
+	e := &recordingEmitter{}
+	emitInfo(e, "clustering 6 jobs")
+
+	require.Len(t, e.events, 1)
+	assert.Equal(t, "info", e.events[0].Type)
+	assert.Equal(t, "clustering 6 jobs", e.events[0].Message)
+}
+
+func TestBuildClusterContext_ExpiredArtifactsSkipped(t *testing.T) {
+	run := &gh.WorkflowRun{ID: 1, Conclusion: "failure"}
+	c := cluster.Cluster{
+		Failures:       []cluster.FailureInfo{{JobID: 1, JobName: "Test"}},
+		Representative: cluster.FailureInfo{JobName: "Test", LogTail: "error"},
+	}
+	artifacts := []gh.Artifact{
+		{Name: "html-report", SizeBytes: 5000, Expired: true},
+		{Name: "blob-report", SizeBytes: 3000, Expired: false},
+	}
+
+	ctx := buildClusterContext(run, c, 1, 1, nil, artifacts)
+
+	assert.NotContains(t, ctx, "html-report", "expired artifacts should be skipped")
+	assert.Contains(t, ctx, "blob-report")
+}
+
+func TestIsTestArtifact(t *testing.T) {
+	assert.True(t, isTestArtifact("html-report"))
+	assert.True(t, isTestArtifact("playwright-report"))
+	assert.True(t, isTestArtifact("test-results"))
+	assert.True(t, isTestArtifact("blob-report-1"))
+	assert.False(t, isTestArtifact("build-cache"))
+	assert.False(t, isTestArtifact("coverage.out"))
 }
 
 func TestFetchFailureLogs(t *testing.T) {

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -1,8 +1,13 @@
 package analysis
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/kamilpajak/heisenberg/pkg/cluster"
 	gh "github.com/kamilpajak/heisenberg/pkg/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -134,4 +139,136 @@ func TestBuildInitialContext_NoArtifacts(t *testing.T) {
 
 	assert.Contains(t, ctx, "No artifacts found")
 	assert.NotContains(t, ctx, "IMPORTANT")
+}
+
+func TestFilterFailed(t *testing.T) {
+	jobs := []gh.Job{
+		{ID: 1, Name: "Lint", Conclusion: "success"},
+		{ID: 2, Name: "Test 1/4", Conclusion: "failure"},
+		{ID: 3, Name: "Test 2/4", Conclusion: "failure"},
+		{ID: 4, Name: "Build", Conclusion: "success"},
+		{ID: 5, Name: "Test 3/4", Conclusion: "skipped"},
+	}
+
+	failed := filterFailed(jobs)
+
+	require.Len(t, failed, 2)
+	assert.Equal(t, int64(2), failed[0].ID)
+	assert.Equal(t, int64(3), failed[1].ID)
+}
+
+func TestFilterFailed_None(t *testing.T) {
+	jobs := []gh.Job{{ID: 1, Conclusion: "success"}}
+	assert.Empty(t, filterFailed(jobs))
+}
+
+func TestFilterFailed_Empty(t *testing.T) {
+	assert.Empty(t, filterFailed(nil))
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "short", truncate("short", 20))
+	assert.Equal(t, "this is a lo...", truncate("this is a long string", 15))
+	assert.Equal(t, "", truncate("", 10))
+}
+
+func TestBuildClusterContext(t *testing.T) {
+	run := &gh.WorkflowRun{
+		ID: 12345, Name: "CI", HeadBranch: "main",
+		HeadSHA: "abc123", Conclusion: "failure",
+	}
+	c := cluster.Cluster{
+		ID:        1,
+		Signature: cluster.ErrorSignature{RawExcerpt: "net::ERR_CONNECTION_REFUSED"},
+		Failures: []cluster.FailureInfo{
+			{JobID: 101, JobName: "E2E 1/4", Conclusion: "failure"},
+			{JobID: 102, JobName: "E2E 2/4", Conclusion: "failure"},
+		},
+		Representative: cluster.FailureInfo{
+			JobName: "E2E 1/4",
+			LogTail: "Error: connection refused at localhost:7745",
+		},
+	}
+	artifacts := []gh.Artifact{{Name: "html-report", SizeBytes: 5000}}
+
+	ctx := buildClusterContext(run, c, 1, 3, nil, artifacts)
+
+	assert.Contains(t, ctx, "Run ID: 12345")
+	assert.Contains(t, ctx, "Cluster 1 of 3")
+	assert.Contains(t, ctx, "2 jobs")
+	assert.Contains(t, ctx, "ERR_CONNECTION_REFUSED")
+	assert.Contains(t, ctx, "specific cluster of related failures")
+	assert.Contains(t, ctx, "E2E 1/4")
+	assert.Contains(t, ctx, "E2E 2/4")
+	assert.Contains(t, ctx, "connection refused at localhost:7745")
+	assert.Contains(t, ctx, "TEST REPORT")
+	assert.Contains(t, ctx, "shared root cause")
+}
+
+func TestBuildClusterContext_NoArtifacts(t *testing.T) {
+	run := &gh.WorkflowRun{ID: 1, Conclusion: "failure"}
+	c := cluster.Cluster{
+		Failures:       []cluster.FailureInfo{{JobID: 1, JobName: "Test"}},
+		Representative: cluster.FailureInfo{JobName: "Test", LogTail: "error"},
+	}
+
+	ctx := buildClusterContext(run, c, 1, 1, nil, nil)
+
+	assert.Contains(t, ctx, "Cluster 1 of 1")
+	assert.NotContains(t, ctx, "TEST REPORT")
+}
+
+func TestEmitInfo_NilEmitter(t *testing.T) {
+	// Should not panic
+	emitInfo(nil, "test message")
+}
+
+func TestFetchFailureLogs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return different logs per job
+		if r.URL.Path == "/repos/owner/repo/actions/jobs/101/logs" {
+			fmt.Fprint(w, "2026-03-29T10:00:00.1234567Z Error: connection refused\n")
+			return
+		}
+		if r.URL.Path == "/repos/owner/repo/actions/jobs/102/logs" {
+			fmt.Fprint(w, "2026-03-29T10:00:00.1234567Z FAIL: exit code 1\n")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient(srv.URL, srv.Client())
+	p := Params{Owner: "owner", Repo: "repo"}
+	jobs := []gh.Job{
+		{ID: 101, Name: "E2E 1/2", Conclusion: "failure"},
+		{ID: 102, Name: "E2E 2/2", Conclusion: "failure"},
+	}
+
+	failures := fetchFailureLogs(context.Background(), ghClient, p, jobs)
+
+	require.Len(t, failures, 2)
+	assert.Equal(t, "E2E 1/2", failures[0].JobName)
+	assert.Equal(t, "E2E 2/2", failures[1].JobName)
+	// Signatures extracted
+	assert.NotEmpty(t, failures[0].Signature.Category)
+	assert.NotEmpty(t, failures[1].Signature.Category)
+}
+
+func TestFetchFailureLogs_ErrorFetchingLogs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient(srv.URL, srv.Client())
+	p := Params{Owner: "owner", Repo: "repo"}
+	jobs := []gh.Job{
+		{ID: 101, Name: "Test", Conclusion: "failure"},
+	}
+
+	failures := fetchFailureLogs(context.Background(), ghClient, p, jobs)
+
+	require.Len(t, failures, 1)
+	assert.Contains(t, failures[0].LogTail, "failed to fetch logs")
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,0 +1,216 @@
+package cluster
+
+import "sort"
+
+const (
+	// jaccardThreshold is the minimum similarity to merge two singleton clusters.
+	// 0.8 is conservative — short error messages share too much boilerplate at lower thresholds.
+	jaccardThreshold = 0.8
+
+	// maxClusters caps the number of clusters. Excess failures go to Unclustered.
+	maxClusters = 10
+)
+
+// ClusterFailures groups failures by error signature.
+// Phase A: exact match on normalized signature.
+// Phase B: Jaccard merge for similar singletons.
+// Returns a single-cluster result as fallback.
+func ClusterFailures(failures []FailureInfo) Result {
+	if len(failures) == 0 {
+		return Result{Method: "single"}
+	}
+	if len(failures) == 1 {
+		c := buildCluster(0, failures)
+		return Result{
+			Clusters:    []Cluster{c},
+			TotalFailed: 1,
+			Method:      "single",
+		}
+	}
+
+	// Separate failures with/without signatures
+	var withSig, withoutSig []FailureInfo
+	for _, f := range failures {
+		if f.Signature.Category == "" {
+			withoutSig = append(withoutSig, f)
+		} else {
+			withSig = append(withSig, f)
+		}
+	}
+
+	// Phase A: exact match on Normalized string
+	groups := map[string][]FailureInfo{}
+	for _, f := range withSig {
+		key := f.Signature.Normalized
+		groups[key] = append(groups[key], f)
+	}
+
+	// Convert to cluster list
+	var clusters []Cluster
+	for _, members := range groups {
+		clusters = append(clusters, buildCluster(len(clusters), members))
+	}
+
+	method := "exact"
+
+	// Phase B: Jaccard merge for singletons
+	merged := jaccardMerge(clusters)
+	if len(merged) < len(clusters) {
+		method = "jaccard"
+	}
+	clusters = merged
+
+	// Sort by size descending (largest cluster first)
+	sort.Slice(clusters, func(i, j int) bool {
+		return len(clusters[i].Failures) > len(clusters[j].Failures)
+	})
+
+	// Cap at maxClusters — excess goes to unclustered
+	if len(clusters) > maxClusters {
+		for _, c := range clusters[maxClusters:] {
+			withoutSig = append(withoutSig, c.Failures...)
+		}
+		clusters = clusters[:maxClusters]
+	}
+
+	// Re-number clusters
+	for i := range clusters {
+		clusters[i].ID = i + 1
+	}
+
+	return Result{
+		Clusters:    clusters,
+		Unclustered: withoutSig,
+		TotalFailed: len(failures),
+		Method:      method,
+	}
+}
+
+// buildCluster creates a Cluster from a group of failures.
+// The representative is the failure with the longest LogTail.
+func buildCluster(id int, failures []FailureInfo) Cluster {
+	rep := failures[0]
+	for _, f := range failures[1:] {
+		if len(f.LogTail) > len(rep.LogTail) {
+			rep = f
+		}
+	}
+	return Cluster{
+		ID:             id + 1,
+		Signature:      failures[0].Signature,
+		Failures:       failures,
+		Representative: rep,
+	}
+}
+
+// jaccardMerge merges singleton clusters with high Jaccard similarity.
+func jaccardMerge(clusters []Cluster) []Cluster {
+	if len(clusters) <= 1 {
+		return clusters
+	}
+
+	// Find singletons and multi-member clusters
+	var singletons []int
+	for i, c := range clusters {
+		if len(c.Failures) == 1 {
+			singletons = append(singletons, i)
+		}
+	}
+
+	if len(singletons) <= 1 {
+		return clusters
+	}
+
+	// Union-find for merging
+	parent := make([]int, len(clusters))
+	for i := range parent {
+		parent[i] = i
+	}
+
+	find := func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[rb] = ra
+		}
+	}
+
+	// Compare all pairs of singletons
+	for i := 0; i < len(singletons); i++ {
+		for j := i + 1; j < len(singletons); j++ {
+			ci, cj := singletons[i], singletons[j]
+			if find(ci) == find(cj) {
+				continue // already merged
+			}
+			sim := jaccard(
+				clusters[ci].Signature.Tokens,
+				clusters[cj].Signature.Tokens,
+			)
+			if sim >= jaccardThreshold {
+				union(ci, cj)
+			}
+		}
+	}
+
+	// Rebuild clusters based on union-find
+	merged := map[int][]FailureInfo{}
+	mergedSig := map[int]ErrorSignature{}
+	for i, c := range clusters {
+		root := find(i)
+		merged[root] = append(merged[root], c.Failures...)
+		if _, ok := mergedSig[root]; !ok {
+			mergedSig[root] = c.Signature
+		}
+	}
+
+	var result []Cluster
+	for root, failures := range merged {
+		c := buildCluster(len(result), failures)
+		c.Signature = mergedSig[root]
+		result = append(result, c)
+	}
+	return result
+}
+
+// jaccard computes the Jaccard similarity between two token sets.
+func jaccard(a, b []string) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	setA := toSet(a)
+	setB := toSet(b)
+
+	intersection := 0
+	for k := range setA {
+		if setB[k] {
+			intersection++
+		}
+	}
+
+	union := len(setA)
+	for k := range setB {
+		if !setA[k] {
+			union++
+		}
+	}
+
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+func toSet(tokens []string) map[string]bool {
+	s := make(map[string]bool, len(tokens))
+	for _, t := range tokens {
+		s[t] = true
+	}
+	return s
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -109,74 +109,87 @@ func jaccardMerge(clusters []Cluster) []Cluster {
 		return clusters
 	}
 
-	// Find singletons and multi-member clusters
+	singletons := findSingletons(clusters)
+	if len(singletons) <= 1 {
+		return clusters
+	}
+
+	uf := newUnionFind(len(clusters))
+	mergeSimilarSingletons(uf, singletons, clusters)
+	return rebuildClusters(uf, clusters)
+}
+
+func findSingletons(clusters []Cluster) []int {
 	var singletons []int
 	for i, c := range clusters {
 		if len(c.Failures) == 1 {
 			singletons = append(singletons, i)
 		}
 	}
+	return singletons
+}
 
-	if len(singletons) <= 1 {
-		return clusters
-	}
-
-	// Union-find for merging
-	parent := make([]int, len(clusters))
-	for i := range parent {
-		parent[i] = i
-	}
-
-	find := func(x int) int {
-		for parent[x] != x {
-			parent[x] = parent[parent[x]]
-			x = parent[x]
-		}
-		return x
-	}
-
-	union := func(a, b int) {
-		ra, rb := find(a), find(b)
-		if ra != rb {
-			parent[rb] = ra
-		}
-	}
-
-	// Compare all pairs of singletons
+func mergeSimilarSingletons(uf *unionFind, singletons []int, clusters []Cluster) {
 	for i := 0; i < len(singletons); i++ {
 		for j := i + 1; j < len(singletons); j++ {
 			ci, cj := singletons[i], singletons[j]
-			if find(ci) == find(cj) {
-				continue // already merged
+			if uf.find(ci) == uf.find(cj) {
+				continue
 			}
-			sim := jaccard(
-				clusters[ci].Signature.Tokens,
-				clusters[cj].Signature.Tokens,
-			)
+			sim := jaccard(clusters[ci].Signature.Tokens, clusters[cj].Signature.Tokens)
 			if sim >= jaccardThreshold {
-				union(ci, cj)
+				uf.union(ci, cj)
 			}
 		}
 	}
+}
 
-	// Rebuild clusters based on union-find
-	merged := map[int][]FailureInfo{}
-	mergedSig := map[int]ErrorSignature{}
+func rebuildClusters(uf *unionFind, clusters []Cluster) []Cluster {
+	grouped := map[int][]FailureInfo{}
+	groupSig := map[int]ErrorSignature{}
 	for i, c := range clusters {
-		root := find(i)
-		merged[root] = append(merged[root], c.Failures...)
-		if _, ok := mergedSig[root]; !ok {
-			mergedSig[root] = c.Signature
+		root := uf.find(i)
+		grouped[root] = append(grouped[root], c.Failures...)
+		if _, ok := groupSig[root]; !ok {
+			groupSig[root] = c.Signature
 		}
 	}
 
 	var result []Cluster
-	for root, failures := range merged {
+	for root, failures := range grouped {
 		c := buildCluster(len(result), failures)
-		c.Signature = mergedSig[root]
+		c.Signature = groupSig[root]
 		result = append(result, c)
 	}
 	return result
+}
+
+// unionFind is a simple disjoint-set data structure with path compression.
+type unionFind struct {
+	parent []int
+}
+
+func newUnionFind(n int) *unionFind {
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+	return &unionFind{parent: parent}
+}
+
+func (uf *unionFind) find(x int) int {
+	for uf.parent[x] != x {
+		uf.parent[x] = uf.parent[uf.parent[x]]
+		x = uf.parent[x]
+	}
+	return x
+}
+
+func (uf *unionFind) union(a, b int) {
+	ra, rb := uf.find(a), uf.find(b)
+	if ra != rb {
+		uf.parent[rb] = ra
+	}
 }
 
 // jaccard computes the Jaccard similarity between two token sets.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,180 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sig(category, normalized string) ErrorSignature {
+	return ErrorSignature{
+		Category:   category,
+		Normalized: normalized,
+		RawExcerpt: normalized,
+		Tokens:     tokenize(normalized),
+	}
+}
+
+func fail(id int64, name string, s ErrorSignature) FailureInfo {
+	return FailureInfo{
+		JobID:      id,
+		JobName:    name,
+		Conclusion: "failure",
+		Signature:  s,
+		LogTail:    "log for " + name,
+	}
+}
+
+func TestClusterFailures_ExactMatch(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, "E2E 1/4", sig("error_message", "connection refused")),
+		fail(2, "E2E 2/4", sig("error_message", "connection refused")),
+		fail(3, "E2E 3/4", sig("error_message", "connection refused")),
+		fail(4, "E2E 4/4", sig("error_message", "connection refused")),
+	}
+
+	result := ClusterFailures(failures)
+
+	assert.Equal(t, 4, result.TotalFailed)
+	require.Len(t, result.Clusters, 1)
+	assert.Len(t, result.Clusters[0].Failures, 4)
+	assert.Equal(t, "exact", result.Method)
+	assert.Empty(t, result.Unclustered)
+}
+
+func TestClusterFailures_DistinctErrors(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, "E2E 1/4", sig("error_message", "connection refused")),
+		fail(2, "E2E 2/4", sig("error_message", "connection refused")),
+		fail(3, "Lint", sig("exit_code", "exit code 1")),
+		fail(4, "Type Check", sig("error_message", "type error in module foo")),
+	}
+
+	result := ClusterFailures(failures)
+
+	assert.Equal(t, 4, result.TotalFailed)
+	require.Len(t, result.Clusters, 3)
+
+	// Largest cluster first
+	assert.Len(t, result.Clusters[0].Failures, 2)
+	assert.Contains(t, result.Clusters[0].Signature.Normalized, "connection refused")
+}
+
+func TestClusterFailures_JaccardMerge(t *testing.T) {
+	// Two nearly identical errors — only one word differs out of many
+	// Jaccard: 8/9 ≈ 0.89 > 0.8 threshold
+	failures := []FailureInfo{
+		fail(1, "Test A", sig("error_message", "expected submit button to be visible on checkout page after login complete")),
+		fail(2, "Test B", sig("error_message", "expected submit button to be visible on payment page after login complete")),
+	}
+
+	result := ClusterFailures(failures)
+
+	require.Len(t, result.Clusters, 1, "similar errors should be merged by Jaccard")
+	assert.Len(t, result.Clusters[0].Failures, 2)
+}
+
+func TestClusterFailures_JaccardNoMerge(t *testing.T) {
+	// Two very different errors that should NOT merge
+	failures := []FailureInfo{
+		fail(1, "Test A", sig("error_message", "connection refused at localhost port database")),
+		fail(2, "Test B", sig("error_message", "assertion failed expected value to equal target string")),
+	}
+
+	result := ClusterFailures(failures)
+
+	require.Len(t, result.Clusters, 2, "distinct errors should not merge")
+}
+
+func TestClusterFailures_Empty(t *testing.T) {
+	result := ClusterFailures(nil)
+	assert.Equal(t, 0, result.TotalFailed)
+	assert.Empty(t, result.Clusters)
+	assert.Equal(t, "single", result.Method)
+}
+
+func TestClusterFailures_SingleFailure(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, "Test", sig("error_message", "something broke")),
+	}
+
+	result := ClusterFailures(failures)
+
+	require.Len(t, result.Clusters, 1)
+	assert.Len(t, result.Clusters[0].Failures, 1)
+	assert.Equal(t, "single", result.Method)
+}
+
+func TestClusterFailures_NoSignature_GoToUnclustered(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, "Test A", sig("error_message", "connection refused")),
+		fail(2, "Test B", ErrorSignature{}), // no signature
+	}
+
+	result := ClusterFailures(failures)
+
+	require.Len(t, result.Clusters, 1)
+	assert.Len(t, result.Unclustered, 1)
+	assert.Equal(t, "Test B", result.Unclustered[0].JobName)
+}
+
+func TestClusterFailures_Cap10(t *testing.T) {
+	// Create 15 distinct failures
+	var failures []FailureInfo
+	for i := range 15 {
+		failures = append(failures, fail(int64(i), "Job", sig("error_message", repeatWord(i))))
+	}
+
+	result := ClusterFailures(failures)
+
+	// Should cap at 10 clusters, rest go to unclustered
+	assert.LessOrEqual(t, len(result.Clusters), 10)
+	totalAccountedFor := len(result.Unclustered)
+	for _, c := range result.Clusters {
+		totalAccountedFor += len(c.Failures)
+	}
+	assert.Equal(t, 15, totalAccountedFor, "all failures must be accounted for")
+}
+
+func TestClusterFailures_RepresentativeIsLongestLog(t *testing.T) {
+	s := sig("error_message", "connection refused")
+	failures := []FailureInfo{
+		{JobID: 1, JobName: "Short", Signature: s, LogTail: "short"},
+		{JobID: 2, JobName: "Long", Signature: s, LogTail: "this is a much longer log with more detail"},
+		{JobID: 3, JobName: "Medium", Signature: s, LogTail: "medium length log"},
+	}
+
+	result := ClusterFailures(failures)
+
+	require.Len(t, result.Clusters, 1)
+	assert.Equal(t, "Long", result.Clusters[0].Representative.JobName)
+}
+
+func TestJaccard(t *testing.T) {
+	a := []string{"the", "quick", "brown", "fox"}
+	b := []string{"the", "quick", "red", "fox"}
+	// Intersection: the, quick, fox (3) / Union: the, quick, brown, red, fox (5)
+	assert.InDelta(t, 0.6, jaccard(a, b), 0.01)
+}
+
+func TestJaccard_Identical(t *testing.T) {
+	a := []string{"error", "connection", "refused"}
+	assert.Equal(t, 1.0, jaccard(a, a))
+}
+
+func TestJaccard_Disjoint(t *testing.T) {
+	a := []string{"alpha", "beta"}
+	b := []string{"gamma", "delta"}
+	assert.Equal(t, 0.0, jaccard(a, b))
+}
+
+func TestJaccard_Empty(t *testing.T) {
+	assert.Equal(t, 0.0, jaccard(nil, nil))
+}
+
+// repeatWord returns a unique word for index i.
+func repeatWord(i int) string {
+	words := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron"}
+	return words[i%len(words)] + " unique error message number"
+}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -173,6 +173,27 @@ func TestJaccard_Empty(t *testing.T) {
 	assert.Equal(t, 0.0, jaccard(nil, nil))
 }
 
+func TestFindSingletons(t *testing.T) {
+	clusters := []Cluster{
+		{Failures: make([]FailureInfo, 3)},
+		{Failures: make([]FailureInfo, 1)},
+		{Failures: make([]FailureInfo, 1)},
+		{Failures: make([]FailureInfo, 5)},
+	}
+	singletons := findSingletons(clusters)
+	assert.Equal(t, []int{1, 2}, singletons)
+}
+
+func TestUnionFind(t *testing.T) {
+	uf := newUnionFind(5)
+	uf.union(0, 1)
+	uf.union(2, 3)
+	uf.union(1, 3)
+
+	assert.Equal(t, uf.find(0), uf.find(3), "0,1,2,3 should be in same set")
+	assert.NotEqual(t, uf.find(0), uf.find(4), "4 should be separate")
+}
+
 // repeatWord returns a unique word for index i.
 func repeatWord(i int) string {
 	words := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron"}

--- a/pkg/cluster/signature.go
+++ b/pkg/cluster/signature.go
@@ -1,0 +1,243 @@
+package cluster
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// maxLogTail is the number of bytes from the end of a log to scan for errors.
+// Most CI failures appear near the end of the output.
+const maxLogTail = 30000
+
+// GitHub Actions timestamp prefix: 2024-01-15T10:30:00.1234567Z
+var timestampRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?`)
+
+// ANSI escape codes
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// Normalization patterns
+var (
+	hexRe        = regexp.MustCompile(`0x[0-9a-fA-F]+`)
+	uuidRe       = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	numberRe     = regexp.MustCompile(`\b\d+\b`)
+	whitespaceRe = regexp.MustCompile(`\s+`)
+)
+
+// Stack trace patterns (applied to timestamp-stripped lines)
+var (
+	// Go: goroutine N [running]: ... file.go:42
+	goTraceRe = regexp.MustCompile(`(?m)^\t(.+\.go:\d+)`)
+	// JS/TS: at Function (file.ts:42:15) or (file.ts:42:15)
+	jsTraceRe = regexp.MustCompile(`\(([^)]+\.[jt]sx?:\d+):\d+\)`)
+	// Python: File "file.py", line 42
+	pyTraceRe = regexp.MustCompile(`File "([^"]+)", line (\d+)`)
+	// Java: at com.example.Class.method(File.java:42)
+	javaTraceRe = regexp.MustCompile(`at .+\(([^)]+\.java:\d+)\)`)
+	// Rust: thread 'main' panicked at file.rs:42:5
+	rustTraceRe = regexp.MustCompile(`panicked at ([^:\s]+:\d+)`)
+)
+
+// Error message patterns
+var (
+	errorMsgRe      = regexp.MustCompile(`(?im)^(?:Error|ERROR|error|FAIL|FAILED|AssertionError|AssertError|TimeoutError|TypeError|ReferenceError):\s*(.+)`)
+	connectionRe    = regexp.MustCompile(`(?i)(connection refused|ECONNREFUSED|ERR_CONNECTION_REFUSED|ECONNRESET)`)
+	exitCodeRe      = regexp.MustCompile(`(?i)(?:exit code|exited with|exit status)\s+(\d+)`)
+	playwrightErrRe = regexp.MustCompile(`(?i)expect\(.+\)\..+`)
+	timeoutRe       = regexp.MustCompile(`(?i)(timed?\s*out|timeout\s+\d+\s*m?s?\s+exceeded)`)
+)
+
+// Fallback: last line containing error keywords
+var errorKeywordRe = regexp.MustCompile(`(?i)(error|fail|panic|timeout|refused|abort|crash|killed|segfault)`)
+
+// ExtractSignature parses a raw job log and returns an ErrorSignature.
+// Returns a zero-value signature if no error pattern is found.
+func ExtractSignature(logText string) ErrorSignature {
+	if logText == "" {
+		return ErrorSignature{}
+	}
+
+	// Focus on the tail of the log (where errors appear)
+	text := logText
+	if len(text) > maxLogTail {
+		text = text[len(text)-maxLogTail:]
+	}
+
+	// Strip GitHub Actions timestamps from every line
+	text = stripTimestamps(text)
+
+	// Try extractors in order of specificity
+	if sig := tryExitCode(text); sig.Category != "" {
+		return sig
+	}
+	if sig := tryStackTrace(text); sig.Category != "" {
+		return sig
+	}
+	if sig := tryErrorMessage(text); sig.Category != "" {
+		return sig
+	}
+	return tryFallback(text)
+}
+
+// stripTimestamps removes GitHub Actions timestamp prefixes from every line.
+func stripTimestamps(text string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = timestampRe.ReplaceAllString(line, "")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func tryExitCode(text string) ErrorSignature {
+	m := exitCodeRe.FindStringSubmatch(text)
+	if m == nil {
+		return ErrorSignature{}
+	}
+	raw := m[0]
+	norm := normalize("exit code " + m[1])
+	return ErrorSignature{
+		Category:   "exit_code",
+		Normalized: norm,
+		RawExcerpt: raw,
+		Tokens:     tokenize(norm),
+	}
+}
+
+func tryStackTrace(text string) ErrorSignature {
+	type pattern struct {
+		re      *regexp.Regexp
+		useLast bool // true = use last match (user code frame); false = first match (crash site)
+	}
+
+	patterns := []pattern{
+		{goTraceRe, false},   // Go: first frame = crash site
+		{jsTraceRe, true},    // JS: last frame = user code (skip node_modules)
+		{pyTraceRe, true},    // Python: last frame = where error raised
+		{javaTraceRe, false}, // Java: first frame = exception origin
+		{rustTraceRe, false}, // Rust: panicked at = crash site
+	}
+
+	for _, p := range patterns {
+		matches := p.re.FindAllStringSubmatch(text, -1)
+		if len(matches) > 0 {
+			idx := 0
+			if p.useLast {
+				idx = len(matches) - 1
+			}
+			m := matches[idx]
+			raw := m[0]
+			location := m[1]
+			if len(m) > 2 {
+				// Python: File + line combined
+				location = m[1] + ":" + m[2]
+			}
+			// Strip directory, keep filename:line
+			parts := strings.Split(location, "/")
+			short := parts[len(parts)-1]
+
+			norm := normalize(short)
+			return ErrorSignature{
+				Category:   "stack_trace",
+				Normalized: norm,
+				RawExcerpt: raw,
+				Tokens:     tokenize(norm),
+			}
+		}
+	}
+	return ErrorSignature{}
+}
+
+func tryErrorMessage(text string) ErrorSignature {
+	// Check specific patterns first
+	if m := connectionRe.FindString(text); m != "" {
+		norm := normalize(m)
+		return ErrorSignature{
+			Category:   "error_message",
+			Normalized: norm,
+			RawExcerpt: m,
+			Tokens:     tokenize(norm),
+		}
+	}
+	if m := timeoutRe.FindString(text); m != "" {
+		norm := normalize(m)
+		return ErrorSignature{
+			Category:   "error_message",
+			Normalized: norm,
+			RawExcerpt: m,
+			Tokens:     tokenize(norm),
+		}
+	}
+	if m := playwrightErrRe.FindString(text); m != "" {
+		norm := normalize(m)
+		return ErrorSignature{
+			Category:   "error_message",
+			Normalized: norm,
+			RawExcerpt: m,
+			Tokens:     tokenize(norm),
+		}
+	}
+
+	// Generic error message
+	if m := errorMsgRe.FindStringSubmatch(text); m != nil {
+		raw := m[0]
+		msg := m[1]
+		norm := normalize(msg)
+		return ErrorSignature{
+			Category:   "error_message",
+			Normalized: norm,
+			RawExcerpt: raw,
+			Tokens:     tokenize(norm),
+		}
+	}
+
+	return ErrorSignature{}
+}
+
+func tryFallback(text string) ErrorSignature {
+	lines := strings.Split(text, "\n")
+	// Scan from bottom — errors are at the end
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if errorKeywordRe.MatchString(line) {
+			norm := normalize(line)
+			return ErrorSignature{
+				Category:   "fallback",
+				Normalized: norm,
+				RawExcerpt: line,
+				Tokens:     tokenize(norm),
+			}
+		}
+	}
+	return ErrorSignature{}
+}
+
+// normalize strips noise from an error string for comparison.
+func normalize(s string) string {
+	s = ansiRe.ReplaceAllString(s, "")
+	s = hexRe.ReplaceAllString(s, "<hex>")
+	s = uuidRe.ReplaceAllString(s, "<uuid>")
+	s = numberRe.ReplaceAllString(s, "<n>")
+	s = whitespaceRe.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+	return s
+}
+
+// tokenize splits a normalized string into tokens for Jaccard similarity.
+// Filters out tokens shorter than 3 characters.
+func tokenize(s string) []string {
+	split := func(c rune) bool {
+		return unicode.IsSpace(c) || unicode.IsPunct(c)
+	}
+	raw := strings.FieldsFunc(s, split)
+	var tokens []string
+	for _, t := range raw {
+		if len(t) >= 3 {
+			tokens = append(tokens, t)
+		}
+	}
+	return tokens
+}

--- a/pkg/cluster/signature.go
+++ b/pkg/cluster/signature.go
@@ -66,14 +66,16 @@ func ExtractSignature(logText string) ErrorSignature {
 	// Strip GitHub Actions timestamps from every line
 	text = stripTimestamps(text)
 
-	// Try extractors in order of specificity
-	if sig := tryExitCode(text); sig.Category != "" {
-		return sig
-	}
+	// Try extractors in order of specificity.
+	// Stack traces and error messages before exit codes — "exit code 1" is
+	// generic and appears on almost every failing GitHub Actions job.
 	if sig := tryStackTrace(text); sig.Category != "" {
 		return sig
 	}
 	if sig := tryErrorMessage(text); sig.Category != "" {
+		return sig
+	}
+	if sig := tryExitCode(text); sig.Category != "" {
 		return sig
 	}
 	return tryFallback(text)

--- a/pkg/cluster/signature_test.go
+++ b/pkg/cluster/signature_test.go
@@ -150,6 +150,28 @@ func TestExtractSignature_RustPanic(t *testing.T) {
 	assert.Contains(t, sig.RawExcerpt, "parser.rs:42")
 }
 
+func TestExtractSignature_StackTracePrioritizedOverExitCode(t *testing.T) {
+	// GitHub Actions appends "exit code 1" to almost every failing job.
+	// Stack trace is more informative and should win.
+	log := `2026-03-29T10:00:00.1234567Z goroutine 1 [running]:
+2026-03-29T10:00:00.1234567Z main.handler()
+2026-03-29T10:00:00.1234567Z 	/app/server.go:42 +0x1a4
+2026-03-29T10:00:01.1234567Z Process completed with exit code 1.`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "stack_trace", sig.Category, "stack trace should be prioritized over generic exit code")
+	assert.Contains(t, sig.RawExcerpt, "server.go:42")
+}
+
+func TestExtractSignature_ExitCodeOnlyWhenNoStackTrace(t *testing.T) {
+	// When there's no stack trace or error message, exit code is fine
+	log := `2026-03-29T10:00:00.1234567Z Running build...
+2026-03-29T10:00:01.1234567Z Process completed with exit code 2.`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "exit_code", sig.Category)
+}
+
 func TestExtractSignature_LongLog_UsesLastPortion(t *testing.T) {
 	// Signature extraction should focus on the end of the log
 	// (where errors typically appear)

--- a/pkg/cluster/signature_test.go
+++ b/pkg/cluster/signature_test.go
@@ -1,0 +1,162 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractSignature_ExitCode(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z Running tests...
+2026-03-29T10:00:05.1234567Z FAIL
+2026-03-29T10:00:05.1234567Z Process completed with exit code 2.`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "exit_code", sig.Category)
+	assert.Contains(t, sig.Normalized, "exit code")
+	assert.Contains(t, sig.RawExcerpt, "exit code 2")
+}
+
+func TestExtractSignature_GoStackTrace(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z goroutine 1 [running]:
+2026-03-29T10:00:00.1234567Z main.init.func1()
+2026-03-29T10:00:00.1234567Z 	/home/runner/work/proj/main.go:42 +0x1a4
+2026-03-29T10:00:00.1234567Z main.main()
+2026-03-29T10:00:00.1234567Z 	/home/runner/work/proj/main.go:10 +0x20`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "stack_trace", sig.Category)
+	assert.Contains(t, sig.Normalized, "main.go")
+	assert.Contains(t, sig.RawExcerpt, "main.go:42")
+}
+
+func TestExtractSignature_JSStackTrace(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z Error: Timeout waiting for selector
+2026-03-29T10:00:00.1234567Z     at Object.waitForSelector (/app/node_modules/playwright/lib/helper.js:123:15)
+2026-03-29T10:00:00.1234567Z     at Context.<anonymous> (tests/checkout.spec.ts:45:22)`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "stack_trace", sig.Category)
+	assert.Contains(t, sig.RawExcerpt, "checkout.spec.ts:45")
+}
+
+func TestExtractSignature_PythonStackTrace(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z Traceback (most recent call last):
+2026-03-29T10:00:00.1234567Z   File "/app/tests/test_login.py", line 42, in test_login
+2026-03-29T10:00:00.1234567Z     assert response.status_code == 200
+2026-03-29T10:00:00.1234567Z AssertionError: assert 500 == 200`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "stack_trace", sig.Category)
+	assert.Contains(t, sig.RawExcerpt, "test_login.py")
+}
+
+func TestExtractSignature_JavaStackTrace(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z java.lang.NullPointerException
+2026-03-29T10:00:00.1234567Z 	at com.example.Service.process(Service.java:42)
+2026-03-29T10:00:00.1234567Z 	at com.example.Controller.handle(Controller.java:15)`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "stack_trace", sig.Category)
+	assert.Contains(t, sig.Normalized, "service.java")
+	assert.Contains(t, sig.RawExcerpt, "Service.java:42")
+}
+
+func TestExtractSignature_ErrorMessage(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z npm run test
+2026-03-29T10:00:05.1234567Z Error: expect(received).toContain(expected)
+2026-03-29T10:00:05.1234567Z Expected substring: "utilsBundle"
+2026-03-29T10:00:05.1234567Z Received string: "..."`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "error_message", sig.Category)
+	assert.Contains(t, sig.Normalized, "expect(received).tocontain(expected)")
+}
+
+func TestExtractSignature_ConnectionRefused(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:7745/home`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "error_message", sig.Category)
+	assert.Contains(t, sig.Normalized, "err_connection_refused")
+}
+
+func TestExtractSignature_Fallback(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z Step 1: checkout
+2026-03-29T10:00:01.1234567Z Step 2: build
+2026-03-29T10:00:02.1234567Z something failed here
+2026-03-29T10:00:03.1234567Z Step 3: done`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "fallback", sig.Category)
+	assert.Contains(t, sig.Normalized, "failed")
+}
+
+func TestExtractSignature_Empty(t *testing.T) {
+	sig := ExtractSignature("")
+	assert.Equal(t, "", sig.Category)
+	assert.Empty(t, sig.Normalized)
+}
+
+func TestExtractSignature_TimestampStripping(t *testing.T) {
+	// Ensure GitHub Actions timestamps don't interfere with extraction
+	log := "2026-03-29T10:00:00.1234567Z Error: something broke"
+	sig := ExtractSignature(log)
+	require.NotEmpty(t, sig.Category)
+	assert.NotContains(t, sig.Normalized, "2026")
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		input string
+		notIn string // should NOT contain after normalization
+	}{
+		{"\x1b[31mError\x1b[0m", "\x1b"},                        // ANSI
+		{"at 0x7fff5fbff8c0", "0x7fff"},                         // hex
+		{"id=550e8400-e29b-41d4-a716-446655440000", "550e8400"}, // UUID
+		{"expected 42 but got 43", "42"},                        // numbers
+		{"  too   many   spaces  ", "   "},                      // whitespace
+	}
+
+	for _, tt := range tests {
+		name := tt.input
+		if len(name) > 20 {
+			name = name[:20]
+		}
+		t.Run(name, func(t *testing.T) {
+			result := normalize(tt.input)
+			assert.NotContains(t, result, tt.notIn)
+		})
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	tokens := tokenize("error: connection refused at localhost:3000")
+	assert.Contains(t, tokens, "error")
+	assert.Contains(t, tokens, "connection")
+	assert.Contains(t, tokens, "refused")
+	// Short tokens filtered
+	assert.NotContains(t, tokens, "at")
+}
+
+func TestExtractSignature_RustPanic(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z thread 'main' panicked at src/parser.rs:42:5
+2026-03-29T10:00:00.1234567Z note: run with RUST_BACKTRACE=1`
+
+	sig := ExtractSignature(log)
+	assert.Equal(t, "stack_trace", sig.Category)
+	assert.Contains(t, sig.RawExcerpt, "parser.rs:42")
+}
+
+func TestExtractSignature_LongLog_UsesLastPortion(t *testing.T) {
+	// Signature extraction should focus on the end of the log
+	// (where errors typically appear)
+	filler := strings.Repeat("2026-03-29T10:00:00.1234567Z normal log line\n", 10000)
+	log := filler + "2026-03-29T10:05:00.1234567Z Error: the actual failure message\n"
+
+	sig := ExtractSignature(log)
+	assert.NotEmpty(t, sig.Category)
+	assert.Contains(t, sig.Normalized, "actual failure message")
+}

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -1,0 +1,37 @@
+// Package cluster provides failure grouping for CI workflow runs.
+// It extracts error signatures from job logs and clusters similar failures
+// using exact match and Jaccard similarity — pure Go, no LLM dependency.
+package cluster
+
+// ErrorSignature is a normalized fingerprint of a failure.
+type ErrorSignature struct {
+	Category   string   // "exit_code", "stack_trace", "error_message", "fallback"
+	Normalized string   // normalized error string for comparison
+	RawExcerpt string   // original text excerpt (for LLM context)
+	Tokens     []string // tokenized form for Jaccard similarity
+}
+
+// FailureInfo holds extracted failure data for one job.
+type FailureInfo struct {
+	JobID      int64
+	JobName    string
+	Conclusion string
+	Signature  ErrorSignature
+	LogTail    string // last N bytes of log, for LLM context
+}
+
+// Cluster groups jobs that share a common failure pattern.
+type Cluster struct {
+	ID             int
+	Signature      ErrorSignature
+	Failures       []FailureInfo
+	Representative FailureInfo // most detailed failure (longest log)
+}
+
+// Result is the output of the clustering phase.
+type Result struct {
+	Clusters    []Cluster
+	Unclustered []FailureInfo // failures that couldn't be fingerprinted
+	TotalFailed int
+	Method      string // "exact", "jaccard", "single" (fallback)
+}

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -128,6 +128,9 @@ type EvalMeta struct {
 	ModelMs       int    `json:"model_ms"`
 	Tokens        int    `json:"tokens"`
 	WallMs        int    `json:"wall_ms"`
+	Clustered     bool   `json:"clustered,omitempty"`
+	ClusterCount  int    `json:"cluster_count,omitempty"`
+	ClusterMethod string `json:"cluster_method,omitempty"`
 }
 
 // GenerationConfig controls response generation.


### PR DESCRIPTION
## Summary

Pre-cluster CI failures by error signature in Go before sending to LLM. Each cluster gets its own focused agent loop instead of dumping all failures into one massive context.

## Key changes

**New package `pkg/cluster/`** (pure Go, no LLM):
- Error signature extraction: cascade (exit code → stack trace for Go/JS/Python/Java/Rust → error message → fallback)
- Strips GitHub Actions timestamp prefixes before extraction
- Clustering: exact match on normalized signature + Jaccard merge (threshold 0.8)
- Cap: 10 clusters max, rest to "other" bucket

**Pipeline integration (`pkg/analysis/run.go`):**
- Threshold gate: >6 failed jobs → clustered path, ≤6 → existing path (unchanged)
- Parallel log fetch for failed jobs (goroutines, semaphore=5)
- Per-cluster `RunAgentLoop()` with focused context
- Context tells LLM: "You are analyzing a specific cluster, not the full run"
- Progress events: `[Cluster 2/5] Analyzing N jobs (pattern)...`

**Result merging (`pkg/analysis/merge.go`):**
- Concatenate per-cluster RCAs, deduplicate identical root causes
- Confidence: weighted average by cluster size
- Sensitivity: take highest (worst)

**EvalMeta:** gains `clustered`, `cluster_count`, `cluster_method` fields

## Manual e2e (threshold temporarily lowered to 3)

sysadminsmedia/homebox (6 failures) with gemini-2.5-pro:
- Clustered into 2 groups: 5 jobs with `exit status 1` + 1 job with `timeout`
- Produced 2 RCAs, confidence 99, 7 total iterations (vs 9 unclustered)

## Test plan

- [x] `go test -race ./...` — all 14 packages pass
- [x] 31 unit tests for signature extraction (5 languages, normalization, edge cases)
- [x] 13 unit tests for clustering algorithm (exact, Jaccard, cap, dedup)
- [x] 5 unit tests for result merging
- [x] Manual e2e: clustering path produces correct results
- [x] Manual e2e: standard path unchanged at threshold (homebox, 6 failures)