### PR TITLE
feat(cli): redesign output with run header, cluster cards, and new flags

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -149,21 +149,8 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve output format
-	if jsonOutput {
-		format = "json"
-	}
-	if format == "" {
-		if isTerminal(os.Stdout) {
-			format = "human"
-		} else {
-			format = "json"
-		}
-	}
-
-	if modelName == "" {
-		modelName = os.Getenv("HEISENBERG_MODEL")
-	}
+	format = resolveFormat(format, jsonOutput, isTerminal(os.Stdout))
+	modelName = resolveModel(modelName)
 
 	emitter := llm.NewTextEmitter(os.Stderr, verbose)
 
@@ -263,6 +250,31 @@ func isTerminal(f *os.File) bool {
 		return false
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// resolveFormat determines output format from flag, --json alias, and TTY detection.
+func resolveFormat(formatFlag string, jsonFlag bool, isTTY bool) string {
+	if jsonFlag {
+		return "json"
+	}
+	if formatFlag != "" {
+		return formatFlag
+	}
+	if isTTY {
+		return "human"
+	}
+	return "json"
+}
+
+// resolveModel determines model name from flag and environment variable.
+func resolveModel(flag string) string {
+	if flag != "" {
+		return flag
+	}
+	if env := os.Getenv("HEISENBERG_MODEL"); env != "" {
+		return env
+	}
+	return ""
 }
 
 func printResult(stderr, stdout io.Writer, r *llm.AnalysisResult) {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +40,9 @@ const (
 var (
 	verbose    bool
 	jsonOutput bool
+	format     string
+	fromEnv    bool
+	runURL     string
 	runID      int64
 	modelName  string
 	port       int
@@ -48,7 +52,7 @@ var rootCmd = &cobra.Command{
 	Use:           "heisenberg <owner/repo>",
 	Short:         "AI-powered test failure analysis",
 	Long:          `Analyzes test artifacts from GitHub repos using AI to identify root causes.`,
-	Args:          cobra.ExactArgs(1),
+	Args:          cobra.MaximumNArgs(1),
 	RunE:          run,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -72,9 +76,13 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show detailed tool call info")
-	rootCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output result as JSON")
+	rootCmd.Flags().StringVar(&format, "format", "", "Output format: human or json (default: auto-detect from TTY)")
+	rootCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output result as JSON (alias for --format json)")
+	rootCmd.Flags().BoolVar(&fromEnv, "from-env", false, "Read owner/repo from GITHUB_REPOSITORY and run ID from GITHUB_RUN_ID")
+	rootCmd.Flags().StringVar(&runURL, "run", "", "GitHub Actions run URL (e.g. https://github.com/org/repo/actions/runs/123)")
 	rootCmd.Flags().Int64Var(&runID, "run-id", 0, "Specific workflow run ID to analyze")
 	rootCmd.Flags().StringVar(&modelName, "model", "", "Gemini model name (env: HEISENBERG_MODEL, default: "+llm.DefaultModel+")")
+	_ = rootCmd.Flags().MarkHidden("json") // backward compat alias
 
 	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "Port to listen on")
 	rootCmd.AddCommand(serveCmd)
@@ -136,12 +144,22 @@ func printError(w io.Writer, err error) int {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	repo := args[0]
-	parts := strings.Split(repo, "/")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid repo format, use: owner/repo")
+	owner, repoName, err := resolveRepo(args)
+	if err != nil {
+		return err
 	}
-	owner, repoName := parts[0], parts[1]
+
+	// Resolve output format
+	if jsonOutput {
+		format = "json"
+	}
+	if format == "" {
+		if isTerminal(os.Stdout) {
+			format = "human"
+		} else {
+			format = "json"
+		}
+	}
 
 	if modelName == "" {
 		modelName = os.Getenv("HEISENBERG_MODEL")
@@ -184,7 +202,7 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if jsonOutput {
+	if format == "json" {
 		return json.NewEncoder(os.Stdout).Encode(result)
 	}
 
@@ -192,24 +210,78 @@ func run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printResult(stderr, stdout io.Writer, r *llm.AnalysisResult) {
-	if r.Category == llm.CategoryDiagnosis {
-		fmt.Fprintln(stderr)
-		dim := color.New(color.FgHiBlack)
-		_, _ = dim.Fprintln(stderr, "  "+strings.Repeat("━", 50))
-		printConfidenceBar(stderr, r.Confidence, r.Sensitivity)
+// resolveRepo determines owner/repo from args, --from-env, or --run URL.
+func resolveRepo(args []string) (owner, repo string, err error) {
+	switch {
+	case runURL != "":
+		return parseRunURL(runURL)
+	case fromEnv:
+		ghRepo := os.Getenv("GITHUB_REPOSITORY")
+		if ghRepo == "" {
+			return "", "", fmt.Errorf("--from-env: GITHUB_REPOSITORY not set")
+		}
+		parts := strings.SplitN(ghRepo, "/", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("--from-env: invalid GITHUB_REPOSITORY: %s", ghRepo)
+		}
+		if ghRunID := os.Getenv("GITHUB_RUN_ID"); ghRunID != "" && runID == 0 {
+			if id, err := strconv.ParseInt(ghRunID, 10, 64); err == nil {
+				runID = id
+			}
+		}
+		return parts[0], parts[1], nil
+	case len(args) > 0:
+		parts := strings.SplitN(args[0], "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("invalid repo format, use: owner/repo")
+		}
+		return parts[0], parts[1], nil
+	default:
+		return "", "", fmt.Errorf("provide owner/repo, --from-env, or --run <URL>")
 	}
+}
 
+// runURLRe matches GitHub Actions run URLs.
+var runURLRe = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/actions/runs/(\d+)`)
+
+// parseRunURL extracts owner, repo, and run ID from a GitHub Actions URL.
+func parseRunURL(url string) (owner, repo string, err error) {
+	m := runURLRe.FindStringSubmatch(url)
+	if m == nil {
+		return "", "", fmt.Errorf("invalid GitHub Actions URL: %s\nExpected: https://github.com/owner/repo/actions/runs/123", url)
+	}
+	if id, parseErr := strconv.ParseInt(m[3], 10, 64); parseErr == nil {
+		runID = id
+	}
+	return m[1], m[2], nil
+}
+
+// isTerminal returns true if the file is a TTY.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func printResult(stderr, stdout io.Writer, r *llm.AnalysisResult) {
 	fmt.Fprintln(stderr)
 
-	// Use structured RCAs if available, otherwise fall back to legacy text
+	// Run-level header
+	printRunHeader(stderr, r)
+
+	if r.Category == llm.CategoryDiagnosis {
+		printConfidenceBar(stderr, r.Confidence, r.Sensitivity)
+		fmt.Fprintln(stderr)
+	}
+
+	// RCA output
 	if len(r.RCAs) > 1 {
-		printRCASummary(stdout, r.RCAs)
+		printClusterSummary(stdout, r.RCAs)
 		for i := range r.RCAs {
 			fmt.Fprintln(stdout)
-			dim := color.New(color.FgHiBlack)
-			_, _ = dim.Fprintf(stdout, "  [%d/%d] ", i+1, len(r.RCAs))
-			printStructuredRCA(stdout, &r.RCAs[i])
+			printClusterCard(stdout, &r.RCAs[i], i+1, len(r.RCAs))
 		}
 	} else if len(r.RCAs) == 1 && r.RCAs[0].Title != "" {
 		printStructuredRCA(stdout, &r.RCAs[0])
@@ -224,13 +296,45 @@ func printResult(stderr, stdout io.Writer, r *llm.AnalysisResult) {
 	}
 }
 
-func printRCASummary(w io.Writer, rcas []llm.RootCauseAnalysis) {
+// printRunHeader renders the top-level run summary.
+func printRunHeader(w io.Writer, r *llm.AnalysisResult) {
 	bold := color.New(color.Bold)
 	dim := color.New(color.FgHiBlack)
 
-	_, _ = bold.Fprintf(w, "  %d failures analyzed:\n\n", len(rcas))
+	// Title line
+	title := "Heisenberg"
+	if r.Owner != "" && r.Repo != "" {
+		title = fmt.Sprintf("Heisenberg — %s/%s", r.Owner, r.Repo)
+	}
+	if r.RunID > 0 {
+		title += fmt.Sprintf(" #%d", r.RunID)
+	}
+	_, _ = bold.Fprintln(w, "  "+title)
+
+	// Metadata line
+	var meta []string
+	if r.Branch != "" {
+		meta = append(meta, "Branch: "+r.Branch)
+	}
+	if r.Event != "" {
+		meta = append(meta, "Event: "+r.Event)
+	}
+	meta = append(meta, "Status: "+r.Category)
+	_, _ = dim.Fprintf(w, "  %s\n", strings.Join(meta, "   "))
+
+	_, _ = dim.Fprintln(w, "  "+strings.Repeat("━", 50))
+}
+
+// printClusterSummary shows a grouped overview of RCAs by bug_location.
+func printClusterSummary(w io.Writer, rcas []llm.RootCauseAnalysis) {
+	bold := color.New(color.Bold)
+	dim := color.New(color.FgHiBlack)
+
+	_, _ = bold.Fprintf(w, "\n  %d root causes found:\n\n", len(rcas))
+
 	for i, rca := range rcas {
-		failureType := strings.ToUpper(rca.FailureType)
+		tag := bugLocationLabel(rca.BugLocation)
+		failureType := strings.ToUpper(string(rca.FailureType))
 		if failureType == "" {
 			failureType = "ERROR"
 		}
@@ -238,15 +342,43 @@ func printRCASummary(w io.Writer, rcas []llm.RootCauseAnalysis) {
 		if rca.Location != nil && rca.Location.FilePath != "" {
 			loc = " in " + formatCodeLocation(rca.Location)
 		}
-		tag := bugLocationTag(rca.BugLocation, rca.BugLocationConfidence)
-		if tag != "" {
-			tag = "  " + tag
-		}
-		_, _ = dim.Fprintf(w, "  %d. %s%s%s\n", i+1, failureType, loc, tag)
+		_, _ = dim.Fprintf(w, "  %d. %-16s %s%s\n", i+1, tag, failureType, loc)
 		if rca.Title != "" {
 			_, _ = dim.Fprintf(w, "     %s\n", rca.Title)
 		}
 	}
+}
+
+// bugLocationLabel returns a colored tag for the bug location.
+func bugLocationLabel(loc llm.BugLocation) string {
+	switch loc {
+	case llm.BugLocationProduction:
+		return color.RedString("[production]")
+	case llm.BugLocationInfrastructure:
+		return color.YellowString("[infra]")
+	case llm.BugLocationTest:
+		return color.CyanString("[test]")
+	default:
+		return color.HiBlackString("[unknown]")
+	}
+}
+
+// printClusterCard renders a single RCA as a cluster card with header.
+func printClusterCard(w io.Writer, rca *llm.RootCauseAnalysis, num, total int) {
+	dim := color.New(color.FgHiBlack)
+	bold := color.New(color.Bold)
+
+	// Cluster header
+	tag := bugLocationLabel(rca.BugLocation)
+	conf := ""
+	if rca.BugLocationConfidence != "" {
+		conf = ", " + rca.BugLocationConfidence + " confidence"
+	}
+	_, _ = dim.Fprintln(w, "  "+strings.Repeat("━", 50))
+	_, _ = bold.Fprintf(w, "  Cluster %d/%d %s%s\n", num, total, tag, conf)
+
+	// Delegate to existing structured RCA renderer
+	printStructuredRCA(w, rca)
 }
 
 // renderRCAHeader prints the failure type, location, bug location tag, and suspected bug file.

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -829,6 +829,37 @@ func TestResolveRepo_FromEnvMissingRepo(t *testing.T) {
 	fromEnv = false
 }
 
+func TestResolveFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     string
+		jsonFlag bool
+		isTTY    bool
+		want     string
+	}{
+		{"json flag", "", true, true, "json"},
+		{"format flag json", "json", false, true, "json"},
+		{"format flag human", "human", false, false, "human"},
+		{"TTY auto-detect", "", false, true, "human"},
+		{"pipe auto-detect", "", false, false, "json"},
+		{"json flag overrides TTY", "", true, false, "json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveFormat(tt.flag, tt.jsonFlag, tt.isTTY))
+		})
+	}
+}
+
+func TestResolveModel(t *testing.T) {
+	assert.Equal(t, "gemini-2.5-pro", resolveModel("gemini-2.5-pro"))
+	assert.Equal(t, "", resolveModel(""))
+
+	t.Setenv("HEISENBERG_MODEL", "gemini-3-pro")
+	assert.Equal(t, "gemini-3-pro", resolveModel(""))
+	assert.Equal(t, "override", resolveModel("override"))
+}
+
 func TestExitCode_APIError(t *testing.T) {
 	var buf bytes.Buffer
 	apiErr := &llm.APIError{

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -766,6 +767,66 @@ func TestBugLocationLabel(t *testing.T) {
 	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationInfrastructure))
 	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationTest))
 	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationUnknown))
+}
+
+func TestPrintClusterSummary(t *testing.T) {
+	var buf bytes.Buffer
+	rcas := []llm.RootCauseAnalysis{
+		{Title: "Timeout", FailureType: llm.FailureTypeTimeout, BugLocation: llm.BugLocationInfrastructure,
+			Location: &llm.CodeLocation{FilePath: "test.spec.ts", LineNumber: 42}},
+		{Title: "Assertion", FailureType: llm.FailureTypeAssertion, BugLocation: llm.BugLocationTest},
+	}
+	printClusterSummary(&buf, rcas)
+	out := buf.String()
+
+	assert.Contains(t, out, "2 root causes found")
+	assert.Contains(t, out, "TIMEOUT")
+	assert.Contains(t, out, "test.spec.ts:42")
+}
+
+func TestPrintClusterSummary_EmptyFailureType(t *testing.T) {
+	var buf bytes.Buffer
+	rcas := []llm.RootCauseAnalysis{
+		{Title: "Unknown", BugLocation: llm.BugLocationUnknown},
+	}
+	printClusterSummary(&buf, rcas)
+	assert.Contains(t, buf.String(), "ERROR")
+}
+
+func TestPrintClusterCard(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:                 "DB timeout",
+		FailureType:           llm.FailureTypeTimeout,
+		BugLocation:           llm.BugLocationInfrastructure,
+		BugLocationConfidence: "high",
+		RootCause:             "DB not started",
+		Remediation:           "Start DB",
+	}
+	printClusterCard(&buf, rca, 2, 3)
+	out := buf.String()
+
+	assert.Contains(t, out, "Cluster 2/3")
+	assert.Contains(t, out, "high confidence")
+	assert.Contains(t, out, "DB not started")
+}
+
+func TestIsTerminal_NotTTY(t *testing.T) {
+	f, err := os.CreateTemp("", "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	defer f.Close()
+	assert.False(t, isTerminal(f))
+}
+
+func TestResolveRepo_FromEnvMissingRepo(t *testing.T) {
+	fromEnv = true
+	runURL = ""
+	t.Setenv("GITHUB_REPOSITORY", "")
+	_, _, err := resolveRepo(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "GITHUB_REPOSITORY not set")
+	fromEnv = false
 }
 
 func TestExitCode_APIError(t *testing.T) {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -62,7 +62,7 @@ func TestPrintResult_NoFailures(t *testing.T) {
 	printResult(&stderr, &stdout, r)
 
 	assert.NotContains(t, stderr.String(), "Confidence")
-	assert.NotContains(t, stderr.String(), "━")
+	assert.Contains(t, stderr.String(), "Heisenberg")
 	assert.Contains(t, stdout.String(), "All tests passing")
 }
 
@@ -243,7 +243,7 @@ func TestPrintResult_MultipleRCAs(t *testing.T) {
 	out := stdout.String()
 
 	// Summary list
-	assert.Contains(t, out, "2 failures analyzed")
+	assert.Contains(t, out, "2 root causes found")
 	assert.Contains(t, out, "1.")
 	assert.Contains(t, out, "2.")
 	assert.Contains(t, out, "ASSERTION")
@@ -275,7 +275,7 @@ func TestPrintResult_SingleRCA_NoSummaryList(t *testing.T) {
 	out := stdout.String()
 
 	// No summary list for single RCA
-	assert.NotContains(t, out, "failures analyzed")
+	assert.NotContains(t, out, "root causes found")
 	// But detail section present
 	assert.Contains(t, out, "TIMEOUT")
 	assert.Contains(t, out, "tests/checkout.spec.ts:45")
@@ -630,12 +630,12 @@ func TestPrintResult_ThreeRCAs_Numbering(t *testing.T) {
 	out := stdout.String()
 
 	// Summary header
-	assert.Contains(t, out, "3 failures analyzed")
+	assert.Contains(t, out, "3 root causes found")
 
-	// Numbering
-	assert.Contains(t, out, "[1/3]")
-	assert.Contains(t, out, "[2/3]")
-	assert.Contains(t, out, "[3/3]")
+	// Cluster cards
+	assert.Contains(t, out, "Cluster 1/3")
+	assert.Contains(t, out, "Cluster 2/3")
+	assert.Contains(t, out, "Cluster 3/3")
 
 	// All failure types present
 	assert.Contains(t, out, "TIMEOUT")
@@ -646,6 +646,126 @@ func TestPrintResult_ThreeRCAs_Numbering(t *testing.T) {
 	assert.Contains(t, out, "Cookie banner")
 	assert.Contains(t, out, "Changed redirect")
 	assert.Contains(t, out, "DNS failure")
+}
+
+func TestParseRunURL(t *testing.T) {
+	tests := []struct {
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{"https://github.com/org/repo/actions/runs/12345", "org", "repo", false},
+		{"https://github.com/microsoft/playwright/actions/runs/23642131867", "microsoft", "playwright", false},
+		{"https://github.com/bad-url", "", "", true},
+		{"not-a-url", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			runID = 0 // reset global
+			owner, repo, err := parseRunURL(tt.url)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantOwner, owner)
+				assert.Equal(t, tt.wantRepo, repo)
+				assert.Positive(t, runID)
+			}
+		})
+	}
+}
+
+func TestResolveRepo_FromArgs(t *testing.T) {
+	fromEnv = false
+	runURL = ""
+	owner, repo, err := resolveRepo([]string{"org/repo"})
+	require.NoError(t, err)
+	assert.Equal(t, "org", owner)
+	assert.Equal(t, "repo", repo)
+}
+
+func TestResolveRepo_InvalidArgs(t *testing.T) {
+	fromEnv = false
+	runURL = ""
+	_, _, err := resolveRepo([]string{"invalid"})
+	assert.Error(t, err)
+}
+
+func TestResolveRepo_NoArgs(t *testing.T) {
+	fromEnv = false
+	runURL = ""
+	_, _, err := resolveRepo(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "provide owner/repo")
+}
+
+func TestResolveRepo_FromEnv(t *testing.T) {
+	fromEnv = true
+	runURL = ""
+	runID = 0
+	t.Setenv("GITHUB_REPOSITORY", "org/repo")
+	t.Setenv("GITHUB_RUN_ID", "99999")
+
+	owner, repo, err := resolveRepo(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "org", owner)
+	assert.Equal(t, "repo", repo)
+	assert.Equal(t, int64(99999), runID)
+
+	fromEnv = false // cleanup
+}
+
+func TestResolveRepo_FromURL(t *testing.T) {
+	fromEnv = false
+	runURL = "https://github.com/microsoft/playwright/actions/runs/12345"
+	runID = 0
+
+	owner, repo, err := resolveRepo(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "microsoft", owner)
+	assert.Equal(t, "playwright", repo)
+	assert.Equal(t, int64(12345), runID)
+
+	runURL = "" // cleanup
+}
+
+func TestPrintRunHeader(t *testing.T) {
+	var buf bytes.Buffer
+	r := &llm.AnalysisResult{
+		Owner:    "org",
+		Repo:     "repo",
+		RunID:    12345,
+		Branch:   "main",
+		Event:    "pull_request",
+		Category: llm.CategoryDiagnosis,
+	}
+	printRunHeader(&buf, r)
+	out := buf.String()
+
+	assert.Contains(t, out, "Heisenberg — org/repo #12345")
+	assert.Contains(t, out, "Branch: main")
+	assert.Contains(t, out, "Event: pull_request")
+	assert.Contains(t, out, "━")
+}
+
+func TestPrintRunHeader_Minimal(t *testing.T) {
+	var buf bytes.Buffer
+	r := &llm.AnalysisResult{Category: llm.CategoryNoFailures}
+	printRunHeader(&buf, r)
+	out := buf.String()
+
+	assert.Contains(t, out, "Heisenberg")
+	assert.NotContains(t, out, "—")
+}
+
+func TestBugLocationLabel(t *testing.T) {
+	// Just verify non-empty returns
+	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationProduction))
+	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationInfrastructure))
+	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationTest))
+	assert.NotEmpty(t, bugLocationLabel(llm.BugLocationUnknown))
 }
 
 func TestExitCode_APIError(t *testing.T) {

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -81,13 +81,13 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 	failedJobs := filterFailed(jobs)
 	if len(failedJobs) > clusterThreshold {
 		result, err := runClustered(ctx, p, ghClient, wfRun, jobs, failedJobs, artifacts)
-		stampRunMeta(result, p.RunID, wfRun)
+		stampRunMeta(result, p, wfRun)
 		return result, err
 	}
 
 	// Standard single-loop path (unchanged for <= threshold failures)
 	result, err := runSingle(ctx, p, ghClient, wfRun, jobs, artifacts)
-	stampRunMeta(result, p.RunID, wfRun)
+	stampRunMeta(result, p, wfRun)
 	return result, err
 }
 
@@ -336,13 +336,16 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
-func stampRunMeta(result *llm.AnalysisResult, runID int64, wfRun *gh.WorkflowRun) {
+func stampRunMeta(result *llm.AnalysisResult, p Params, wfRun *gh.WorkflowRun) {
 	if result == nil {
 		return
 	}
-	result.RunID = runID
+	result.RunID = p.RunID
+	result.Owner = p.Owner
+	result.Repo = p.Repo
 	result.Branch = wfRun.HeadBranch
 	result.CommitSHA = wfRun.HeadSHA
+	result.Event = wfRun.Event
 }
 
 func emitInfo(e llm.ProgressEmitter, msg string) {

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -244,17 +244,21 @@ func TestBuildUnclusteredCluster_Single(t *testing.T) {
 
 func TestStampRunMeta(t *testing.T) {
 	result := &llm.AnalysisResult{Text: "test"}
-	wfRun := &gh.WorkflowRun{HeadBranch: "main", HeadSHA: "abc123"}
-	stampRunMeta(result, 12345, wfRun)
+	p := Params{RunID: 12345, Owner: "org", Repo: "repo"}
+	wfRun := &gh.WorkflowRun{HeadBranch: "main", HeadSHA: "abc123", Event: "pull_request"}
+	stampRunMeta(result, p, wfRun)
 
 	assert.Equal(t, int64(12345), result.RunID)
+	assert.Equal(t, "org", result.Owner)
+	assert.Equal(t, "repo", result.Repo)
 	assert.Equal(t, "main", result.Branch)
 	assert.Equal(t, "abc123", result.CommitSHA)
+	assert.Equal(t, "pull_request", result.Event)
 }
 
 func TestStampRunMeta_NilResult(t *testing.T) {
 	// Should not panic
-	stampRunMeta(nil, 12345, &gh.WorkflowRun{})
+	stampRunMeta(nil, Params{}, &gh.WorkflowRun{})
 }
 
 func TestEmitInfo_NilEmitter(t *testing.T) {

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -115,8 +115,11 @@ type AnalysisResult struct {
 	Sensitivity string              `json:"sensitivity"`          // "high", "medium", "low", meaningful only for "diagnosis"
 	RCAs        []RootCauseAnalysis `json:"analyses,omitempty"`   // Structured diagnoses, one per failing test
 	RunID       int64               `json:"run_id,omitempty"`     // GitHub workflow run ID
+	Owner       string              `json:"owner,omitempty"`      // Repository owner
+	Repo        string              `json:"repo,omitempty"`       // Repository name
 	Branch      string              `json:"branch,omitempty"`     // Git branch name
 	CommitSHA   string              `json:"commit_sha,omitempty"` // Git commit SHA
+	Event       string              `json:"event,omitempty"`      // GitHub event type (push, pull_request)
 	Eval        *EvalMeta           `json:"eval,omitempty"`       // Performance metadata for eval
 }
 


### PR DESCRIPTION
## Summary

Redesign CLI human output and add CI-friendly flags.

## New flags

- `--from-env`: reads `GITHUB_REPOSITORY` + `GITHUB_RUN_ID` — zero-config CI mode
- `--format human|json`: replaces `--json` (kept as hidden alias), auto-detects TTY
- `--run <URL>`: parse GitHub Actions run URL (copy from browser, paste)

## Human output redesign

**Before:**
```
  ✓  Used 7/30 iterations
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Confidence: 90% ████████████████████░░░░
  2 failures analyzed:
  [1/2] TIMEOUT in tests/checkout.spec.ts:45
  [2/2] ASSERTION in tests/login.spec.ts:12
```

**After:**
```
  Heisenberg — org/repo #12345
  Branch: main   Event: pull_request   Status: diagnosis
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Confidence: 90% ████████████████████░░░░

  2 root causes found:
  1. [test]           TIMEOUT in tests/checkout.spec.ts:45
  2. [production]     ASSERTION in tests/login.spec.ts:12

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Cluster 1/2 [test]
  TIMEOUT in tests/checkout.spec.ts:45
  ...

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Cluster 2/2 [production]
  ...
```

## Test plan

- [x] `go test -race ./...` — all 14 packages pass
- [x] URL parsing: valid URLs, invalid URLs, edge cases
- [x] `--from-env`: with/without env vars, run ID parsing
- [x] Run header: with/without metadata, minimal mode
- [x] Cluster summary: colored bug_location tags
- [x] Backward compat: `--json` still works (hidden alias)