### PR TITLE
feat(llm): add fix_confidence field and remediation quality prompt

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -495,7 +495,16 @@ func printStructuredRCA(w io.Writer, rca *llm.RootCauseAnalysis) {
 	}
 
 	// Remediation
-	_, _ = fixColor.Fprintln(w, "  Fix")
+	fixLabel := "  Fix"
+	switch rca.FixConfidence {
+	case "high":
+		fixLabel = "  Fix (high confidence)"
+	case "medium":
+		fixLabel = "  Fix (medium confidence)"
+	case "low":
+		fixLabel = "  Fix (suggested direction)"
+	}
+	_, _ = fixColor.Fprintln(w, fixLabel)
 	_, _ = dim.Fprintln(w, separator)
 	fmt.Fprintln(w, wrapBullets(rca.Remediation, maxLineWidth, "  "))
 }

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -439,6 +439,22 @@ func TestPrintStructuredRCA_FixConfidenceLow(t *testing.T) {
 	assert.Contains(t, out, "Fix (suggested direction)")
 }
 
+func TestPrintStructuredRCA_FixConfidenceMedium(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:         "Config mismatch",
+		FailureType:   llm.FailureTypeAssertion,
+		RootCause:     "Rate limits differ",
+		Remediation:   "Adjust rate limiter config",
+		FixConfidence: "medium",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "Fix (medium confidence)")
+}
+
 func TestPrintStructuredRCA_NoFixConfidence(t *testing.T) {
 	var buf bytes.Buffer
 	rca := &llm.RootCauseAnalysis{

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -407,6 +407,55 @@ func TestWrapBullets(t *testing.T) {
 	}
 }
 
+func TestPrintStructuredRCA_FixConfidenceHigh(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:         "Selector changed",
+		FailureType:   llm.FailureTypeTimeout,
+		RootCause:     "CSS selector outdated",
+		Remediation:   "Update selector to [data-loaded]",
+		FixConfidence: "high",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "Fix (high confidence)")
+}
+
+func TestPrintStructuredRCA_FixConfidenceLow(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:         "Rate limit test",
+		FailureType:   llm.FailureTypeAssertion,
+		RootCause:     "Limits mismatch",
+		Remediation:   "Mock maxRequests",
+		FixConfidence: "low",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "Fix (suggested direction)")
+}
+
+func TestPrintStructuredRCA_NoFixConfidence(t *testing.T) {
+	var buf bytes.Buffer
+	rca := &llm.RootCauseAnalysis{
+		Title:       "Some failure",
+		FailureType: llm.FailureTypeAssertion,
+		RootCause:   "Something broke",
+		Remediation: "Fix it",
+	}
+
+	printStructuredRCA(&buf, rca)
+	out := buf.String()
+
+	assert.Contains(t, out, "  Fix\n")
+	assert.NotContains(t, out, "confidence")
+	assert.NotContains(t, out, "direction")
+}
+
 func TestPrintStructuredRCA_WordWrap(t *testing.T) {
 	var buf bytes.Buffer
 	rca := &llm.RootCauseAnalysis{

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -668,6 +668,11 @@ func ToolDeclarations() []llm.FunctionDeclaration {
 									Type:        "string",
 									Description: "How to fix it - actionable guidance for resolving the issue.",
 								},
+								"fix_confidence": {
+									Type:        "string",
+									Description: "How actionable the remediation is. high: inspected source, specific fix. medium: correct direction, details may vary. low: general suggestion without source inspection.",
+									Enum:        []string{"high", "medium", "low"},
+								},
 							},
 						},
 					},

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -163,6 +163,21 @@ For "diagnosis" category, provide an "analyses" array. Each entry contains:
   - root_cause: Why it failed (the underlying issue)
   - evidence: Array of supporting data points
   - remediation: How to fix it (actionable guidance)
+  - fix_confidence: How actionable the remediation is (high/medium/low)
+
+Remediation quality rules:
+  - Before suggesting to mock, patch, or override a property, use get_repo_file to read the
+    implementation of the class or module involved. Do not suggest mocking private/readonly
+    fields, sealed classes, or final methods.
+  - If you cannot inspect the implementation, state that the fix direction is likely correct
+    but the exact approach may need adjustment.
+  - Prefer concrete, copy-pasteable guidance when you have enough context. When you don't,
+    say so explicitly.
+
+Fix confidence:
+  - "high": You inspected the relevant source code and the fix is specific and copy-pasteable
+  - "medium": Direction is correct but implementation details may vary (e.g. you didn't read the class)
+  - "low": General suggestion — you didn't inspect the implementation
 
 Top-level fields (outside analyses):
   - confidence: 0-100 score (overall diagnosis confidence)

--- a/pkg/llm/rca.go
+++ b/pkg/llm/rca.go
@@ -45,6 +45,7 @@ type RootCauseAnalysis struct {
 	RootCause             string        `json:"root_cause"`                        // Why it failed
 	Evidence              []Evidence    `json:"evidence"`                          // Supporting data points
 	Remediation           string        `json:"remediation"`                       // How to fix it
+	FixConfidence         string        `json:"fix_confidence,omitempty"`          // high, medium, low
 }
 
 // CodeLocation identifies a specific location in source code.
@@ -104,6 +105,7 @@ func ParseRCAFromArgs(args map[string]any) *RootCauseAnalysis {
 		Symptom:               stringArg(args, "symptom"),
 		RootCause:             stringArg(args, "root_cause"),
 		Remediation:           stringArg(args, "remediation"),
+		FixConfidence:         stringArg(args, "fix_confidence"),
 	}
 
 	// Parse test failure location

--- a/pkg/llm/rca.go
+++ b/pkg/llm/rca.go
@@ -105,7 +105,7 @@ func ParseRCAFromArgs(args map[string]any) *RootCauseAnalysis {
 		Symptom:               stringArg(args, "symptom"),
 		RootCause:             stringArg(args, "root_cause"),
 		Remediation:           stringArg(args, "remediation"),
-		FixConfidence:         stringArg(args, "fix_confidence"),
+		FixConfidence:         strings.ToLower(stringArg(args, "fix_confidence")),
 	}
 
 	// Parse test failure location

--- a/pkg/llm/rca_test.go
+++ b/pkg/llm/rca_test.go
@@ -443,3 +443,65 @@ func TestParseRCAsFromArgs_Empty(t *testing.T) {
 	rcas := ParseRCAsFromArgs(nil)
 	assert.Empty(t, rcas)
 }
+
+func TestRCA_FixConfidence_JSONSerialization(t *testing.T) {
+	rca := &RootCauseAnalysis{
+		Title:         "Rate limit test fails",
+		FailureType:   FailureTypeAssertion,
+		RootCause:     "Tests expect 20/h but production has 100,000/h",
+		Remediation:   "Mock the rate limiter or lower production limits",
+		FixConfidence: "medium",
+	}
+
+	data, err := json.Marshal(rca)
+	require.NoError(t, err)
+
+	var decoded RootCauseAnalysis
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "medium", decoded.FixConfidence)
+
+	// Verify JSON key name
+	assert.Contains(t, string(data), `"fix_confidence":"medium"`)
+}
+
+func TestRCA_FixConfidence_OmittedWhenEmpty(t *testing.T) {
+	rca := &RootCauseAnalysis{
+		Title:       "Some failure",
+		FailureType: FailureTypeTimeout,
+		RootCause:   "Slow",
+		Remediation: "Speed it up",
+	}
+
+	data, err := json.Marshal(rca)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "fix_confidence")
+}
+
+func TestParseRCAFromArgs_WithFixConfidence(t *testing.T) {
+	args := map[string]any{
+		"title":          "Rate limit mismatch",
+		"failure_type":   "assertion",
+		"symptom":        "Expected 429, got 200",
+		"root_cause":     "Rate limits set to 100,000",
+		"remediation":    "Mock maxRequests",
+		"fix_confidence": "low",
+	}
+
+	rca := ParseRCAFromArgs(args)
+	assert.Equal(t, "low", rca.FixConfidence)
+}
+
+func TestParseRCAFromArgs_WithoutFixConfidence(t *testing.T) {
+	args := map[string]any{
+		"title":        "Error",
+		"failure_type": "timeout",
+		"symptom":      "Timed out",
+		"root_cause":   "Slow",
+		"remediation":  "Speed it up",
+	}
+
+	rca := ParseRCAFromArgs(args)
+	assert.Empty(t, rca.FixConfidence)
+}

--- a/pkg/llm/rca_test.go
+++ b/pkg/llm/rca_test.go
@@ -505,3 +505,16 @@ func TestParseRCAFromArgs_WithoutFixConfidence(t *testing.T) {
 	rca := ParseRCAFromArgs(args)
 	assert.Empty(t, rca.FixConfidence)
 }
+
+func TestParseRCAFromArgs_FixConfidence_CaseNormalized(t *testing.T) {
+	args := map[string]any{
+		"title":          "Error",
+		"failure_type":   "assertion",
+		"root_cause":     "Bug",
+		"remediation":    "Fix it",
+		"fix_confidence": "High",
+	}
+
+	rca := ParseRCAFromArgs(args)
+	assert.Equal(t, "high", rca.FixConfidence, "LLM may return capitalized values")
+}


### PR DESCRIPTION
## Summary

- Add `fix_confidence` (high/medium/low) to RCA schema — distinguishes "exact fix" from "directional suggestion"
- Update system prompt with remediation quality rules: inspect implementation before suggesting mocking
- CLI renders fix_confidence as label: "Fix (high confidence)" / "Fix (suggested direction)"

## Context

Real-world testing on gridscribe showed Heisenberg suggests "mock maxRequests" for a `private readonly` TypeScript field. Diagnosis was 100% correct but remediation wasn't implementation-aware. This change instructs the model to inspect source code before suggesting mocks, and signals confidence level to the user.

## Test plan

- [x] TDD: 8 new tests (rca_test.go + main_test.go)
- [x] All existing tests pass
- [ ] Rerun gridscribe Analyze Failures workflow to verify fix_confidence appears