### PR TITLE
fix(llm): deduplicate progress output in non-TTY mode

### DIFF
--- a/pkg/llm/progress.go
+++ b/pkg/llm/progress.go
@@ -47,10 +47,11 @@ type TextEmitter struct {
 	verbose bool
 
 	// Compact mode state (non-verbose TTY)
-	lastStep int
-	lastMax  int
-	lastTool string
-	failed   bool
+	lastStep        int
+	lastMax         int
+	lastTool        string
+	lastEmittedStep int // last step number emitted to non-TTY output (dedup)
+	failed          bool
 }
 
 // MarkFailed signals that the analysis ended with an error.
@@ -236,8 +237,12 @@ func (e *TextEmitter) Emit(ev ProgressEvent) {
 		e.lastTool = ev.Tool
 		if e.verbose {
 			e.emitToolVerbose(ev)
-		} else {
+		} else if e.tty {
 			e.stopSpinner()
+			e.compactProgress()
+		} else if ev.Step != e.lastEmittedStep {
+			// Non-TTY: emit one line per step (dedup multiple tool calls in same iteration)
+			e.lastEmittedStep = ev.Step
 			e.compactProgress()
 		}
 

--- a/pkg/llm/progress_test.go
+++ b/pkg/llm/progress_test.go
@@ -413,3 +413,68 @@ func TestCompactMode_ToolNonTTY_HasNewline(t *testing.T) {
 	assert.True(t, strings.HasSuffix(out, "\n"), "non-TTY compact tool output should end with newline")
 	assert.NotContains(t, out, "\033", "non-TTY output should not contain ANSI escapes")
 }
+
+func TestCompactMode_NonTTY_DedupSameStep(t *testing.T) {
+	e, buf := newCompactTestEmitter()
+
+	// Iteration 1: three tool calls (get_job_logs x3) — should emit only one line
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Len(t, lines, 1, "multiple tool calls in same step should produce one line")
+	assert.Contains(t, lines[0], "1/30")
+}
+
+func TestCompactMode_NonTTY_DifferentStepsAllEmit(t *testing.T) {
+	e, buf := newCompactTestEmitter()
+
+	// Each step has one tool call — all should emit
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 2, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 3, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 4, MaxStep: 30, Tool: "done"})
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Len(t, lines, 4, "different steps should each produce a line")
+	assert.Contains(t, lines[0], "1/30")
+	assert.Contains(t, lines[1], "2/30")
+	assert.Contains(t, lines[2], "3/30")
+	assert.Contains(t, lines[3], "4/30")
+}
+
+func TestCompactMode_NonTTY_RealisticSequence(t *testing.T) {
+	e, buf := newCompactTestEmitter()
+
+	// Simulates the gridscribe run:
+	// iter 1: 3x get_job_logs
+	// iter 2: model thinking (no tools — step event only)
+	// iter 3: 2x get_repo_file
+	// iter 4: 1x get_repo_file
+	// iter 5: 1x get_repo_file
+	// iter 6: model thinking
+	// iter 7: 1x get_repo_file
+	// iter 8: done
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 3, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 3, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 4, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 5, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 7, MaxStep: 30, Tool: "get_repo_file"})
+	e.Emit(ProgressEvent{Type: "tool", Step: 8, MaxStep: 30, Tool: "done"})
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	// Steps 2 and 6 have no tool calls (model thinking only) — not emitted in non-TTY
+	assert.Len(t, lines, 6, "9 tool events across 6 distinct steps should produce 6 lines")
+	assert.Contains(t, lines[0], "Reading logs")
+	assert.Contains(t, lines[0], "1/30")
+	assert.Contains(t, lines[1], "Reading source")
+	assert.Contains(t, lines[1], "3/30")
+	assert.Contains(t, lines[4], "Reading source")
+	assert.Contains(t, lines[4], "7/30")
+	assert.Contains(t, lines[5], "Finalizing")
+	assert.Contains(t, lines[5], "8/30")
+}


### PR DESCRIPTION
## Summary

In CI (non-TTY), multiple tool calls within the same agent iteration produced duplicate progress lines:

```
  Reading logs       1/30
  Reading logs       1/30
  Reading logs       1/30
  Analyzing          2/30
  Reading source     3/30
  Reading source     3/30
```

Now emits one line per iteration step:

```
  Reading logs       1/30
  Analyzing          2/30
  Reading source     3/30
  Reading source     4/30
```

TTY mode unchanged (single line overwritten with `\r`).

## Test plan

- [x] 3 new tests: dedup same step, different steps all emit, realistic CI sequence
- [x] All existing compact mode tests pass