### PR TITLE
fix: address issues from Azure live testing

### DIFF
--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -69,9 +69,9 @@ func (c *Client) Name() string { return "azure" }
 // AnalysisHints returns Azure-specific strategy hints for the LLM.
 func (c *Client) AnalysisHints() string {
 	return `Azure Pipelines specific notes:
-- Use get_test_results first to see structured test failures with error messages and stack traces
-- Then use job logs for additional context around the failures
-- Pipeline definition files are typically in the repo root or a pipelines/ directory`
+- IMPORTANT: Call get_test_results FIRST before reading any logs. It returns structured test failures with error messages and stack traces directly from Azure's Test Results API.
+- Use job logs only for additional context after reviewing structured test results.
+- Pipeline definition files are typically in the repo root or a pipelines/ directory.`
 }
 
 // Internal types for JSON deserialization of Azure DevOps API responses.
@@ -131,6 +131,8 @@ func mapResult(result string) string {
 func stripBranchPrefix(ref string) string {
 	ref = strings.TrimPrefix(ref, "refs/heads/")
 	ref = strings.TrimPrefix(ref, "refs/tags/")
+	ref = strings.TrimPrefix(ref, "refs/")
+	ref = strings.TrimSuffix(ref, "/merge")
 	return ref
 }
 

--- a/pkg/azure/client_test.go
+++ b/pkg/azure/client_test.go
@@ -531,6 +531,23 @@ func TestMapResult(t *testing.T) {
 	}
 }
 
+func TestStripBranchPrefix(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"refs/heads/main", "main"},
+		{"refs/heads/feat/FA-209", "feat/FA-209"},
+		{"refs/pull/21507/merge", "pull/21507"},
+		{"refs/tags/v1.0", "v1.0"},
+		{"main", "main"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripBranchPrefix(tt.in))
+		})
+	}
+}
+
 func TestMapChangeType(t *testing.T) {
 	tests := []struct{ in, want string }{
 		{"add", "added"},

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -105,7 +105,7 @@ func describeEmptyResponse(c *Candidate) string {
 }
 
 // DefaultModel is the Gemini model used when no override is specified.
-const DefaultModel = "gemini-3-pro-preview"
+const DefaultModel = "gemini-2.5-pro"
 
 // NewClient creates a new LLM client (Google Gemini).
 // If model is empty, DefaultModel is used.


### PR DESCRIPTION
## Summary

Fixes 3 issues discovered during live testing against Azure DevOps pipelines:

- Strip `refs/pull/N/merge` branch prefix — was showing raw ref in output
- Change default model to `gemini-2.5-pro` — `gemini-3-pro-preview` gets stuck in file-reading loops on complex Azure builds (30 iter timeout). 2.5-pro was 3/3 reliable in live tests.
- Strengthen Azure `AnalysisHints` to prioritize `get_test_results` tool — model was ignoring it and reading logs instead

## Test plan

- [x] `TestStripBranchPrefix` — refs/heads, refs/tags, refs/pull, plain branch
- [x] `go test ./...` passes
- [ ] Re-run `buildId=174150` — verify branch shows `feat/FA-284`, model is `gemini-2.5-pro`