### PR TITLE
feat(azure): add cross-repo file access for multi-repo pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ testdata/e2e/eval.jsonl
 web/node_modules/
 web/.svelte-kit/
 web/build/
-cli
+/cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `analyze` subcommand — explicit entry point for test failure analysis (`heisenberg analyze owner/repo`)
+- Azure DevOps flags: `--azure-org`, `--azure-project`, `--azure-test-repo` (replaces `--org`, `--project`, `--test-repo`)
+- Short flag aliases: `-f` (format), `-r` (run)
+- Cross-repository file access for Azure DevOps multi-repo pipelines (`--azure-test-repo`)
+- `--debug` flag for full agent conversation trace
+
+### Changed
+
+- Bare `heisenberg` now shows help with subcommand list instead of erroring
+- Global flags (`--verbose`, `--format`, `--debug`) available to all subcommands
+- Output format resolved before target resolution — piped errors now correctly produce JSON
+
+### Deprecated
+
+- `--org`, `--project`, `--test-repo` flags (use `--azure-org`, `--azure-project`, `--azure-test-repo`)
+- Running analysis on root command (`heisenberg owner/repo`) — use `heisenberg analyze owner/repo`
+
 ## [0.3.1] - 2026-03-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-01
+
 ### Added
 
 - `analyze` subcommand — explicit entry point for test failure analysis (`heisenberg analyze owner/repo`)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ export GITHUB_TOKEN=ghp_...
 export GOOGLE_API_KEY=AIza...
 
 heisenberg doctor                           # verify your setup
-heisenberg owner/repo                       # analyze latest failed run
+heisenberg analyze owner/repo               # analyze latest failed run
 ```
 
 `heisenberg doctor` checks tokens, network connectivity, Playwright, and config:
@@ -110,12 +110,12 @@ Under the hood: an agentic tool-calling loop (up to 30 iterations) lets Gemini d
 ## How It Works
 
 ```
-heisenberg owner/repo
+heisenberg analyze owner/repo
        │
        ▼
 ┌─────────────────────────────┐
 │  Fetch workflow run from    │
-│  GitHub Actions             │
+│  GitHub Actions / Azure     │
 └─────────────┬───────────────┘
               │
               ▼
@@ -161,25 +161,31 @@ heisenberg owner/repo
 
 ```bash
 # Analyze the latest failed workflow run
-heisenberg owner/repo
+heisenberg analyze owner/repo
 
 # Analyze a specific run by URL (paste from your browser)
-heisenberg --run https://github.com/org/repo/actions/runs/123456
+heisenberg analyze -r https://github.com/org/repo/actions/runs/123456
 
 # Analyze a specific run by ID
-heisenberg owner/repo --run-id 123456
+heisenberg analyze owner/repo --run-id 123456
 
 # JSON output for CI pipelines
-heisenberg owner/repo --format json
+heisenberg analyze owner/repo -f json
 
 # CI mode — read repo and run ID from GitHub Actions environment
-heisenberg --from-env
+heisenberg analyze --from-env
 
 # Show detailed tool call info
-heisenberg owner/repo --verbose
+heisenberg analyze owner/repo --verbose
 
 # Override the Gemini model
-heisenberg owner/repo --model gemini-2.5-flash
+heisenberg analyze owner/repo --model gemini-2.5-flash
+
+# Azure DevOps — analyze by build URL
+heisenberg analyze -r "https://dev.azure.com/org/project/_build/results?buildId=456"
+
+# Azure DevOps — explicit org/project
+heisenberg analyze --azure-org myorg --azure-project myproject --run-id 789
 
 # Start the local web dashboard
 heisenberg serve

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -88,7 +88,7 @@ repository URL or CI environment variables.`,
   $ heisenberg analyze owner/repo
 
   # Analyze a specific CI run by URL
-  $ heisenberg analyze owner/repo -r "https://github.com/owner/repo/actions/runs/123"
+  $ heisenberg analyze -r "https://github.com/owner/repo/actions/runs/123"
 
   # Auto-detect from CI environment
   $ heisenberg analyze --from-env
@@ -445,11 +445,17 @@ func resolveAzureEnv(flagRunID int64) (*targetInfo, error) {
 }
 
 // extractAzureOrg extracts the organization name from an Azure DevOps collection URI.
-// e.g., "https://dev.azure.com/myorg/" → "myorg"
+// Supports both formats:
+//
+//	"https://dev.azure.com/myorg/"       → "myorg"
+//	"https://myorg.visualstudio.com/"    → "myorg"
 func extractAzureOrg(uri string) string {
 	u, err := url.Parse(strings.TrimRight(uri, "/"))
 	if err != nil || u.Host == "" {
 		return ""
+	}
+	if strings.HasSuffix(u.Host, ".visualstudio.com") {
+		return strings.TrimSuffix(u.Host, ".visualstudio.com")
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) > 0 && parts[0] != "" {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -467,11 +467,14 @@ func buildProvider(target *targetInfo, cfg *config.Config) ci.Provider {
 		client := azure.NewClient(target.owner, target.repo, pat)
 		if testRepo != "" {
 			parts := strings.SplitN(testRepo, "/", 2)
-			repo := parts[0]
-			project := target.owner // same org by default
+			var project, repo string
 			if len(parts) == 2 {
 				project = parts[0]
 				repo = parts[1]
+			} else {
+				// Single name: use as both project and repo (Azure DevOps convention)
+				project = parts[0]
+				repo = parts[0]
 			}
 			client.ExtraRepos = []ci.RepoRef{{Project: project, Repo: repo}}
 		}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -60,19 +60,49 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:           "heisenberg <owner/repo>",
-	Short:         "AI-powered test failure analysis",
-	Long:          `Analyzes CI test failures using AI to identify root causes. Supports GitHub Actions and Azure Pipelines.`,
-	Args:          cobra.MaximumNArgs(1),
-	RunE:          run,
+	Use:   "heisenberg",
+	Short: "AI-powered test failure analysis",
+	Long:  `Analyzes CI test failures using AI to identify root causes. Supports GitHub Actions and Azure Pipelines.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 && !fromEnv && runURL == "" && azureOrg == "" && azureProject == "" && providerFlag == "" {
+			return cmd.Help()
+		}
+		return run(cmd, args)
+	},
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }
 
+var analyzeCmd = &cobra.Command{
+	Use:   "analyze [owner/repo]",
+	Short: "Analyze CI test failures",
+	Long: `Analyzes CI test failures using AI to identify root causes.
+Supports GitHub Actions and Azure Pipelines. Auto-detects provider from
+repository URL or CI environment variables.`,
+	Args:          cobra.MaximumNArgs(1),
+	RunE:          run,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Example: `  # Analyze the latest failing run
+  $ heisenberg analyze owner/repo
+
+  # Analyze a specific CI run by URL
+  $ heisenberg analyze owner/repo -r "https://github.com/owner/repo/actions/runs/123"
+
+  # Auto-detect from CI environment
+  $ heisenberg analyze --from-env
+
+  # JSON output for CI integration
+  $ heisenberg analyze --from-env -f json`,
+}
+
 var serveCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "Start the local web dashboard",
-	RunE:  serve,
+	Use:           "serve",
+	Short:         "Start the local web dashboard",
+	RunE:          serve,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 var versionCmd = &cobra.Command{
@@ -86,24 +116,61 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show detailed tool call info")
-	rootCmd.Flags().StringVar(&format, "format", "", "Output format: human or json (default: auto-detect from TTY)")
-	rootCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output result as JSON (alias for --format json)")
-	rootCmd.Flags().BoolVar(&fromEnv, "from-env", false, "Read repo/run from CI environment variables (GitHub Actions or Azure Pipelines)")
-	rootCmd.Flags().StringVar(&runURL, "run", "", "CI run URL (GitHub Actions or Azure Pipelines)")
-	rootCmd.Flags().Int64Var(&runID, "run-id", 0, "Specific workflow run ID to analyze")
-	rootCmd.Flags().StringVar(&modelName, "model", "", "Gemini model name (env: HEISENBERG_MODEL, default: "+llm.DefaultModel+")")
-	rootCmd.Flags().StringVar(&providerFlag, "provider", "", "CI provider: github or azure (default: auto-detect)")
-	rootCmd.Flags().StringVar(&azureOrg, "org", "", "Azure DevOps organization")
-	rootCmd.Flags().StringVar(&azureProject, "project", "", "Azure DevOps project")
-	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "Additional repository for test code (project/repo)")
-	rootCmd.Flags().BoolVar(&debug, "debug", false, "Write full agent conversation trace to a debug file")
-	_ = rootCmd.Flags().MarkHidden("json") // backward compat alias
+	// Global flags (available to all subcommands via PersistentFlags)
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show detailed tool call info")
+	rootCmd.PersistentFlags().StringVarP(&format, "format", "f", "", "Output format: human or json (default: auto-detect from TTY)")
+	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output result as JSON (alias for --format json)")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Write full agent conversation trace to a debug file")
+	_ = rootCmd.PersistentFlags().MarkHidden("json") // backward compat alias
+
+	// Analyze-specific flags (on analyzeCmd)
+	analyzeCmd.Flags().BoolVar(&fromEnv, "from-env", false, "Read repo/run from CI environment variables (GitHub Actions or Azure Pipelines)")
+	analyzeCmd.Flags().StringVarP(&runURL, "run", "r", "", "CI run URL (GitHub Actions or Azure Pipelines)")
+	analyzeCmd.Flags().Int64Var(&runID, "run-id", 0, "Specific workflow run ID to analyze")
+	analyzeCmd.Flags().StringVar(&modelName, "model", "", "Gemini model name (env: HEISENBERG_MODEL, default: "+llm.DefaultModel+")")
+	analyzeCmd.Flags().StringVar(&providerFlag, "provider", "", "CI provider: github or azure (default: auto-detect)")
+	analyzeCmd.Flags().StringVar(&azureOrg, "azure-org", "", "Azure DevOps organization")
+	analyzeCmd.Flags().StringVar(&azureProject, "azure-project", "", "Azure DevOps project")
+	analyzeCmd.Flags().StringVar(&testRepo, "azure-test-repo", "", "Additional repository for test code (project/repo)")
+
+	// Deprecated aliases for renamed flags (on analyzeCmd)
+	analyzeCmd.Flags().StringVar(&azureOrg, "org", "", "Azure DevOps organization")
+	analyzeCmd.Flags().StringVar(&azureProject, "project", "", "Azure DevOps project")
+	analyzeCmd.Flags().StringVar(&testRepo, "test-repo", "", "Additional repository for test code (project/repo)")
+	_ = analyzeCmd.Flags().MarkDeprecated("org", "use --azure-org instead")
+	_ = analyzeCmd.Flags().MarkDeprecated("project", "use --azure-project instead")
+	_ = analyzeCmd.Flags().MarkDeprecated("test-repo", "use --azure-test-repo instead")
+
+	// Hidden copies on rootCmd for backward compat (heisenberg owner/repo --from-env etc.)
+	rootCmd.Flags().BoolVar(&fromEnv, "from-env", false, "")
+	rootCmd.Flags().StringVarP(&runURL, "run", "r", "", "")
+	rootCmd.Flags().Int64Var(&runID, "run-id", 0, "")
+	rootCmd.Flags().StringVar(&modelName, "model", "", "")
+	rootCmd.Flags().StringVar(&providerFlag, "provider", "", "")
+	rootCmd.Flags().StringVar(&azureOrg, "azure-org", "", "")
+	rootCmd.Flags().StringVar(&azureProject, "azure-project", "", "")
+	rootCmd.Flags().StringVar(&testRepo, "azure-test-repo", "", "")
+	rootCmd.Flags().StringVar(&azureOrg, "org", "", "")
+	rootCmd.Flags().StringVar(&azureProject, "project", "", "")
+	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "")
+	_ = rootCmd.Flags().MarkDeprecated("org", "use --azure-org instead")
+	_ = rootCmd.Flags().MarkDeprecated("project", "use --azure-project instead")
+	_ = rootCmd.Flags().MarkDeprecated("test-repo", "use --azure-test-repo instead")
+	hideRootFlags("from-env", "run", "run-id", "model", "provider",
+		"azure-org", "azure-project", "azure-test-repo")
 
 	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "Port to listen on")
+	rootCmd.AddCommand(analyzeCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(doctorCmd)
+}
+
+// hideRootFlags marks flags as hidden on rootCmd (backward compat only, not shown in help).
+func hideRootFlags(names ...string) {
+	for _, name := range names {
+		_ = rootCmd.Flags().MarkHidden(name)
+	}
 }
 
 func main() {
@@ -176,12 +243,12 @@ func printError(w io.Writer, err error) int {
 }
 
 func run(cmd *cobra.Command, args []string) error {
+	format = resolveFormat(format, jsonOutput, isTerminal(os.Stdout))
+
 	target, err := resolveTarget(args, runID)
 	if err != nil {
 		return err
 	}
-
-	format = resolveFormat(format, jsonOutput, isTerminal(os.Stdout))
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -281,7 +348,7 @@ func resolveTarget(args []string, flagRunID int64) (*targetInfo, error) {
 	// 3. Explicit Azure flags
 	if providerFlag == "azure" || azureOrg != "" || azureProject != "" {
 		if azureOrg == "" || azureProject == "" {
-			return nil, fmt.Errorf("azure requires both --org and --project flags")
+			return nil, fmt.Errorf("azure requires both --azure-org and --azure-project flags")
 		}
 		return &targetInfo{
 			provider: "azure",

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -55,6 +55,7 @@ var (
 	providerFlag string
 	azureOrg     string
 	azureProject string
+	testRepo     string
 )
 
 var rootCmd = &cobra.Command{
@@ -94,6 +95,7 @@ func init() {
 	rootCmd.Flags().StringVar(&providerFlag, "provider", "", "CI provider: github or azure (default: auto-detect)")
 	rootCmd.Flags().StringVar(&azureOrg, "org", "", "Azure DevOps organization")
 	rootCmd.Flags().StringVar(&azureProject, "project", "", "Azure DevOps project")
+	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "Additional repository for test code (project/repo)")
 	_ = rootCmd.Flags().MarkHidden("json") // backward compat alias
 
 	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "Port to listen on")
@@ -446,7 +448,18 @@ func buildProvider(target *targetInfo, cfg *config.Config) ci.Provider {
 		if pat == "" && cfg != nil {
 			pat = cfg.AzureDevOpsPAT
 		}
-		return azure.NewClient(target.owner, target.repo, pat)
+		client := azure.NewClient(target.owner, target.repo, pat)
+		if testRepo != "" {
+			parts := strings.SplitN(testRepo, "/", 2)
+			repo := parts[0]
+			project := target.owner // same org by default
+			if len(parts) == 2 {
+				project = parts[0]
+				repo = parts[1]
+			}
+			client.ExtraRepos = []ci.RepoRef{{Project: project, Repo: repo}}
+		}
+		return client
 	default:
 		token := ""
 		if cfg != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -56,6 +56,7 @@ var (
 	azureOrg     string
 	azureProject string
 	testRepo     string
+	debug        bool
 )
 
 var rootCmd = &cobra.Command{
@@ -96,6 +97,7 @@ func init() {
 	rootCmd.Flags().StringVar(&azureOrg, "org", "", "Azure DevOps organization")
 	rootCmd.Flags().StringVar(&azureProject, "project", "", "Azure DevOps project")
 	rootCmd.Flags().StringVar(&testRepo, "test-repo", "", "Additional repository for test code (project/repo)")
+	rootCmd.Flags().BoolVar(&debug, "debug", false, "Write full agent conversation trace to a debug file")
 	_ = rootCmd.Flags().MarkHidden("json") // backward compat alias
 
 	serveCmd.Flags().IntVarP(&port, "port", "p", 8080, "Port to listen on")
@@ -189,7 +191,21 @@ func run(cmd *cobra.Command, args []string) error {
 
 	modelName = resolveModel(modelName, cfg.Model)
 
-	emitter := llm.NewTextEmitter(os.Stderr, verbose)
+	var emitter llm.ProgressEmitter
+	textEmitter := llm.NewTextEmitter(os.Stderr, verbose)
+	if debug {
+		debugEmitter, debugErr := llm.NewDebugEmitter(textEmitter)
+		if debugErr != nil {
+			return debugErr
+		}
+		defer func() {
+			debugEmitter.Close()
+			fmt.Fprintf(os.Stderr, "  Debug log: %s\n", debugEmitter.Path())
+		}()
+		emitter = debugEmitter
+	} else {
+		emitter = textEmitter
+	}
 
 	ciProvider := buildProvider(target, cfg)
 
@@ -205,12 +221,12 @@ func run(cmd *cobra.Command, args []string) error {
 		GoogleAPIKey: cfg.GoogleAPIKey,
 	})
 	if err != nil {
-		emitter.MarkFailed()
-		emitter.Close()
+		textEmitter.MarkFailed()
+		textEmitter.Close()
 		return err
 	}
 
-	emitter.Close()
+	textEmitter.Close()
 
 	// Persist to SaaS dashboard (if configured)
 	if client := saas.NewClient(); client != nil {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -937,6 +937,9 @@ func TestExtractAzureOrg(t *testing.T) {
 		{"https://dev.azure.com/myorg/", "myorg"},
 		{"https://dev.azure.com/myorg", "myorg"},
 		{"https://dev.azure.com/my-org/", "my-org"},
+		{"https://myorg.visualstudio.com/", "myorg"},
+		{"https://myorg.visualstudio.com", "myorg"},
+		{"https://my-org.visualstudio.com/DefaultCollection", "my-org"},
 		{"", ""},
 		{"not-a-url", ""},
 	}
@@ -1410,6 +1413,14 @@ func TestAnalyzeCmd_HasExamples(t *testing.T) {
 	assert.Contains(t, cmd.Example, "--from-env")
 	assert.Contains(t, cmd.Example, "analyze owner/repo")
 	assert.Contains(t, cmd.Example, "-f json")
+
+	// --run URL example should NOT include owner/repo (URL already contains it)
+	for _, line := range strings.Split(cmd.Example, "\n") {
+		if strings.Contains(line, "-r ") && strings.Contains(line, "http") {
+			assert.NotRegexp(t, `analyze\s+\S+/\S+\s+-r`, line,
+				"--run URL example should not include owner/repo — URL already identifies the target")
+		}
+	}
 }
 
 func TestGlobalFlags_OnPersistentFlags(t *testing.T) {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/fatih/color"
+	"github.com/kamilpajak/heisenberg/pkg/azure"
 	"github.com/kamilpajak/heisenberg/pkg/config"
 	"github.com/kamilpajak/heisenberg/pkg/llm"
 	"github.com/stretchr/testify/assert"
@@ -963,6 +964,31 @@ func TestBuildProvider_AzureFromEnv(t *testing.T) {
 	target := &targetInfo{provider: "azure", owner: "myorg", repo: "myproject"}
 	p := buildProvider(target, &config.Config{})
 	assert.Equal(t, "azure", p.Name())
+}
+
+func TestBuildProvider_AzureWithTestRepo(t *testing.T) {
+	target := &targetInfo{provider: "azure", owner: "myorg", repo: "myproject"}
+	testRepo = "e2e-tests"
+	defer func() { testRepo = "" }()
+
+	p := buildProvider(target, &config.Config{AzureDevOpsPAT: "pat"})
+	azClient := p.(*azure.Client)
+	require.Len(t, azClient.ExtraRepos, 1)
+	// Single name: project and repo should BOTH be the test repo name, not the org
+	assert.Equal(t, "e2e-tests", azClient.ExtraRepos[0].Project)
+	assert.Equal(t, "e2e-tests", azClient.ExtraRepos[0].Repo)
+}
+
+func TestBuildProvider_AzureWithTestRepoExplicitProject(t *testing.T) {
+	target := &targetInfo{provider: "azure", owner: "myorg", repo: "myproject"}
+	testRepo = "other-project/test-repo"
+	defer func() { testRepo = "" }()
+
+	p := buildProvider(target, &config.Config{AzureDevOpsPAT: "pat"})
+	azClient := p.(*azure.Client)
+	require.Len(t, azClient.ExtraRepos, 1)
+	assert.Equal(t, "other-project", azClient.ExtraRepos[0].Project)
+	assert.Equal(t, "test-repo", azClient.ExtraRepos[0].Repo)
 }
 
 func TestPrintRunHeader(t *testing.T) {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -908,7 +908,7 @@ func TestResolveTarget_AzureFlags_MissingOrg(t *testing.T) {
 
 	_, err := resolveTarget(nil, runID)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "--org")
+	assert.Contains(t, err.Error(), "--azure-org")
 
 	providerFlag = ""
 	azureProject = ""
@@ -1393,4 +1393,153 @@ func TestPrintResult_ExecutiveSummary_SectionNames(t *testing.T) {
 	assert.Contains(t, out, "Cause")
 	assert.Contains(t, out, "Fix")
 	assert.NotContains(t, out, "Root Cause", "should use shorter 'Cause' heading")
+}
+
+// --- Phase 1: analyze subcommand + flag relocation ---
+
+func TestAnalyzeCmd_Exists(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"analyze"})
+	require.NoError(t, err)
+	assert.Equal(t, "analyze", cmd.Name())
+}
+
+func TestAnalyzeCmd_HasExamples(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"analyze"})
+	require.NotNil(t, cmd)
+	assert.NotEmpty(t, cmd.Example)
+	assert.Contains(t, cmd.Example, "--from-env")
+	assert.Contains(t, cmd.Example, "analyze owner/repo")
+	assert.Contains(t, cmd.Example, "-f json")
+}
+
+func TestGlobalFlags_OnPersistentFlags(t *testing.T) {
+	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("verbose"))
+	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("format"))
+	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("debug"))
+}
+
+func TestAnalyzeCmd_OwnFlags(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"analyze"})
+	require.NotNil(t, cmd)
+	assert.NotNil(t, cmd.Flags().Lookup("from-env"))
+	assert.NotNil(t, cmd.Flags().Lookup("run"))
+	assert.NotNil(t, cmd.Flags().Lookup("run-id"))
+	assert.NotNil(t, cmd.Flags().Lookup("model"))
+	assert.NotNil(t, cmd.Flags().Lookup("provider"))
+}
+
+func TestRootCmd_UseIsClean(t *testing.T) {
+	assert.Equal(t, "heisenberg", rootCmd.Use)
+}
+
+func TestRootCmd_BackwardCompat_Runnable(t *testing.T) {
+	assert.True(t, rootCmd.Runnable(), "rootCmd must remain runnable for backward compat")
+}
+
+func TestRootCmd_AnalyzeFlags_Hidden(t *testing.T) {
+	flag := rootCmd.Flags().Lookup("from-env")
+	require.NotNil(t, flag, "rootCmd must accept --from-env for backward compat")
+	assert.True(t, flag.Hidden, "--from-env should be hidden on rootCmd")
+}
+
+// --- Phase 2: Rename provider-specific flags ---
+
+func TestAnalyzeCmd_AzureFlags(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"analyze"})
+	require.NotNil(t, cmd)
+	assert.NotNil(t, cmd.Flags().Lookup("azure-org"), "--azure-org should exist")
+	assert.NotNil(t, cmd.Flags().Lookup("azure-project"), "--azure-project should exist")
+	assert.NotNil(t, cmd.Flags().Lookup("azure-test-repo"), "--azure-test-repo should exist")
+}
+
+func TestAnalyzeCmd_DeprecatedFlags(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"analyze"})
+	require.NotNil(t, cmd)
+	orgFlag := cmd.Flags().Lookup("org")
+	require.NotNil(t, orgFlag, "--org should still exist as deprecated alias")
+	assert.NotEmpty(t, orgFlag.Deprecated)
+}
+
+// --- Phase 3: Short flag aliases ---
+
+func TestShortFlags(t *testing.T) {
+	fmtFlag := rootCmd.PersistentFlags().ShorthandLookup("f")
+	require.NotNil(t, fmtFlag, "-f should exist")
+	assert.Equal(t, "format", fmtFlag.Name)
+
+	cmd, _, _ := rootCmd.Find([]string{"analyze"})
+	require.NotNil(t, cmd)
+	runFlag := cmd.Flags().ShorthandLookup("r")
+	require.NotNil(t, runFlag, "-r should exist")
+	assert.Equal(t, "run", runFlag.Name)
+}
+
+// --- CR fixes ---
+
+func TestRootCmd_ProviderFlagFallsThrough(t *testing.T) {
+	// "heisenberg --provider azure" should NOT show help — should fall through
+	// to run() which returns a proper validation error.
+	providerFlag = "azure"
+	azureOrg = ""
+	azureProject = ""
+	fromEnv = false
+	runURL = ""
+	defer func() { providerFlag = "" }()
+
+	err := rootCmd.RunE(rootCmd, nil)
+	// Should be an error from resolveTarget, not nil (help)
+	require.Error(t, err, "should fall through to run(), not show help")
+	assert.Contains(t, err.Error(), "--azure-org")
+}
+
+func TestRootCmd_AzureProjectFallsThrough(t *testing.T) {
+	// "heisenberg --azure-project foo" should NOT show help
+	azureProject = "foo"
+	azureOrg = ""
+	fromEnv = false
+	runURL = ""
+	providerFlag = ""
+	defer func() { azureProject = "" }()
+
+	err := rootCmd.RunE(rootCmd, nil)
+	assert.Error(t, err)
+}
+
+func TestServeCmd_SilencesErrors(t *testing.T) {
+	assert.True(t, serveCmd.SilenceUsage, "serveCmd should silence usage on error")
+	assert.True(t, serveCmd.SilenceErrors, "serveCmd should silence errors")
+}
+
+func TestRootCmd_DeprecatedFlagsOnRoot(t *testing.T) {
+	// Legacy flags on rootCmd should also be marked deprecated
+	orgFlag := rootCmd.Flags().Lookup("org")
+	require.NotNil(t, orgFlag)
+	assert.NotEmpty(t, orgFlag.Deprecated, "--org on rootCmd should be deprecated")
+
+	projectFlag := rootCmd.Flags().Lookup("project")
+	require.NotNil(t, projectFlag)
+	assert.NotEmpty(t, projectFlag.Deprecated, "--project on rootCmd should be deprecated")
+
+	testRepoFlag := rootCmd.Flags().Lookup("test-repo")
+	require.NotNil(t, testRepoFlag)
+	assert.NotEmpty(t, testRepoFlag.Deprecated, "--test-repo on rootCmd should be deprecated")
+}
+
+func TestRun_ResolvesFormatBeforeError(t *testing.T) {
+	// Pre-existing bug: resolveFormat ran AFTER resolveTarget, so if
+	// resolveTarget failed, format was still "" and printError would
+	// use human output even when piped (non-TTY expects JSON).
+	oldFormat := format
+	oldFromEnv := fromEnv
+	oldRunURL := runURL
+	format = ""
+	fromEnv = false
+	runURL = ""
+	defer func() { format = oldFormat; fromEnv = oldFromEnv; runURL = oldRunURL }()
+
+	// run() with invalid args — fails at resolveTarget
+	_ = run(rootCmd, []string{"invalid"})
+
+	// format should already be resolved (not still "")
+	assert.NotEmpty(t, format, "format should be resolved before resolveTarget can fail")
 }

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -245,14 +245,21 @@ func (h *ToolHandler) tryOtherRepos(ctx context.Context, path string) (string, b
 		h.otherReposResolved = true
 		repos, err := crp.DiscoverRepos(ctx, h.RunID)
 		if err != nil || len(repos) == 0 {
+			emitInfo(h.Emitter, "No additional repositories discovered")
 			return "", false
 		}
 		h.otherRepos = repos
+		names := make([]string, len(repos))
+		for i, r := range repos {
+			names[i] = r.Project + "/" + r.Repo
+		}
+		emitInfo(h.Emitter, fmt.Sprintf("Discovered %d additional repo(s): %s", len(repos), strings.Join(names, ", ")))
 	}
 
 	for _, repo := range h.otherRepos {
 		content, err := crp.GetFileFromRepo(ctx, repo, path)
 		if err == nil {
+			emitInfo(h.Emitter, fmt.Sprintf("Found %s in %s/%s", path, repo.Project, repo.Repo))
 			return content, true
 		}
 	}

--- a/pkg/analysis/tools.go
+++ b/pkg/analysis/tools.go
@@ -30,6 +30,8 @@ type ToolHandler struct {
 	confidence          int                     // 0-100, set by done tool
 	sensitivity         string                  // "high", "medium", "low", set by done tool
 	rcas                []llm.RootCauseAnalysis // structured RCAs, set by done tool
+	otherRepos          []ci.RepoRef            // cached discovered repos for cross-repo lookups
+	otherReposResolved  bool                    // true after first discovery attempt
 }
 
 // Execute dispatches a function call, returning the result string and whether
@@ -218,14 +220,43 @@ func (h *ToolHandler) getRepoFile(ctx context.Context, args map[string]any) (str
 
 	content, err := h.CI.GetRepoFile(ctx, path)
 	if err != nil {
-		// Smart 404: if file not found, return directory listing of parent
 		if strings.Contains(err.Error(), "404") {
+			// Try cross-repo lookup before falling back to smartNotFound
+			if crossContent, ok := h.tryOtherRepos(ctx, path); ok {
+				return crossContent, false, nil
+			}
 			return h.smartNotFound(ctx, path), false, nil
 		}
 		return errorResult(err), false, nil
 	}
 
 	return content, false, nil
+}
+
+// tryOtherRepos attempts to find a file in additional repositories discovered
+// from the pipeline definition. Returns the file content and true if found.
+func (h *ToolHandler) tryOtherRepos(ctx context.Context, path string) (string, bool) {
+	crp, ok := h.CI.(ci.CrossRepoProvider)
+	if !ok {
+		return "", false
+	}
+
+	if !h.otherReposResolved {
+		h.otherReposResolved = true
+		repos, err := crp.DiscoverRepos(ctx, h.RunID)
+		if err != nil || len(repos) == 0 {
+			return "", false
+		}
+		h.otherRepos = repos
+	}
+
+	for _, repo := range h.otherRepos {
+		content, err := crp.GetFileFromRepo(ctx, repo, path)
+		if err == nil {
+			return content, true
+		}
+	}
+	return "", false
 }
 
 // smartNotFound returns an error with a directory listing of the parent folder.

--- a/pkg/analysis/tools_test.go
+++ b/pkg/analysis/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1589,4 +1590,81 @@ func TestToolDeclarations_Azure(t *testing.T) {
 		names[i] = d.Name
 	}
 	assert.Contains(t, names, "get_test_results")
+}
+
+// mockCrossRepoProvider implements ci.Provider + ci.CrossRepoProvider for testing.
+type mockCrossRepoProvider struct {
+	ci.Provider
+	repos   []ci.RepoRef
+	files   map[string]string // "project/repo:path" → content
+	repoErr error
+}
+
+func (m *mockCrossRepoProvider) Name() string          { return "mock-cross" }
+func (m *mockCrossRepoProvider) AnalysisHints() string { return "" }
+func (m *mockCrossRepoProvider) GetRepoFile(_ context.Context, path string) (string, error) {
+	return "", fmt.Errorf("file not found: 404 %s", path)
+}
+func (m *mockCrossRepoProvider) ListDirectory(_ context.Context, _ string) ([]string, error) {
+	return nil, fmt.Errorf("not found")
+}
+func (m *mockCrossRepoProvider) DiscoverRepos(_ context.Context, _ int64) ([]ci.RepoRef, error) {
+	return m.repos, m.repoErr
+}
+func (m *mockCrossRepoProvider) GetFileFromRepo(_ context.Context, repo ci.RepoRef, path string) (string, error) {
+	key := repo.Project + "/" + repo.Repo + ":" + path
+	if content, ok := m.files[key]; ok {
+		return content, nil
+	}
+	return "", fmt.Errorf("file not found: 404 %s", path)
+}
+
+func TestGetRepoFile_CrossRepoFallback(t *testing.T) {
+	mock := &mockCrossRepoProvider{
+		repos: []ci.RepoRef{{Project: "tests-project", Repo: "e2e-tests"}},
+		files: map[string]string{
+			"tests-project/e2e-tests:com/test/MyTest.java": "public class MyTest {}",
+		},
+	}
+	h := &ToolHandler{CI: mock, RunID: 100, hasReadErrorContext: true}
+	result, isDone, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "com/test/MyTest.java"},
+	})
+	require.NoError(t, err)
+	assert.False(t, isDone)
+	assert.Equal(t, "public class MyTest {}", result)
+}
+
+func TestGetRepoFile_CrossRepoAllFail(t *testing.T) {
+	mock := &mockCrossRepoProvider{
+		repos: []ci.RepoRef{{Project: "tests-project", Repo: "e2e-tests"}},
+		files: map[string]string{}, // nothing found
+	}
+	h := &ToolHandler{CI: mock, RunID: 100, hasReadErrorContext: true}
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "nonexistent.java"},
+	})
+	require.NoError(t, err)
+	// Should fall back to smartNotFound (returns error JSON)
+	assert.Contains(t, result, "file not found")
+}
+
+func TestGetRepoFile_NoCrossRepo(t *testing.T) {
+	// GitHub client doesn't implement CrossRepoProvider — should just smartNotFound
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient("owner", "repo", srv.URL, srv.Client())
+	h := &ToolHandler{CI: ghClient, RunID: 100, hasReadErrorContext: true}
+	result, _, err := h.Execute(context.Background(), llm.FunctionCall{
+		Name: "get_repo_file",
+		Args: map[string]any{"path": "missing.ts"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result, "file not found")
 }

--- a/pkg/analysis/tools_test.go
+++ b/pkg/analysis/tools_test.go
@@ -1626,7 +1626,9 @@ func TestGetRepoFile_CrossRepoFallback(t *testing.T) {
 			"tests-project/e2e-tests:com/test/MyTest.java": "public class MyTest {}",
 		},
 	}
-	h := &ToolHandler{CI: mock, RunID: 100, hasReadErrorContext: true}
+	var emitted []string
+	emitter := &testEmitter{messages: &emitted}
+	h := &ToolHandler{CI: mock, RunID: 100, hasReadErrorContext: true, Emitter: emitter}
 	result, isDone, err := h.Execute(context.Background(), llm.FunctionCall{
 		Name: "get_repo_file",
 		Args: map[string]any{"path": "com/test/MyTest.java"},
@@ -1634,6 +1636,21 @@ func TestGetRepoFile_CrossRepoFallback(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, isDone)
 	assert.Equal(t, "public class MyTest {}", result)
+	// Verify logging
+	assert.True(t, len(emitted) >= 2, "expected discovery + found messages")
+	assert.Contains(t, emitted[0], "Discovered 1 additional repo")
+	assert.Contains(t, emitted[1], "Found com/test/MyTest.java in tests-project/e2e-tests")
+}
+
+// testEmitter captures emitted info messages for test assertions.
+type testEmitter struct {
+	messages *[]string
+}
+
+func (e *testEmitter) Emit(ev llm.ProgressEvent) {
+	if ev.Type == "info" {
+		*e.messages = append(*e.messages, ev.Message)
+	}
 }
 
 func TestGetRepoFile_CrossRepoAllFail(t *testing.T) {

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -76,8 +76,7 @@ func (c *Client) Name() string { return "azure" }
 // AnalysisHints returns Azure-specific strategy hints for the LLM.
 func (c *Client) AnalysisHints() string {
 	return `Azure Pipelines specific notes:
-- IMPORTANT: Call get_test_results FIRST before reading any logs. It returns structured test failures with error messages and stack traces directly from Azure's Test Results API.
-- Use job logs only for additional context after reviewing structured test results.
+- Try get_test_results early to check for structured test failures with error messages and stack traces. If it returns no results, the pipeline does not publish test results — use job logs instead.
 - Pipeline definition files are typically in the repo root or a pipelines/ directory.
 - If a test file path from stack traces is not found in this repository, the tool will automatically search additional repositories used by this pipeline.`
 }

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -35,6 +35,13 @@ type Client struct {
 	// Cached artifact download URLs, populated by ListArtifacts.
 	// Key: artifact ID, Value: download URL.
 	artifactURLs map[int64]string
+
+	// Cached discovered repos from pipeline definition.
+	discoveredRepos []ci.RepoRef
+	reposDiscovered bool
+
+	// Extra repos pre-seeded via --test-repo flag.
+	ExtraRepos []ci.RepoRef
 }
 
 // NewClient creates a new Azure DevOps client bound to a specific org/project.
@@ -71,7 +78,8 @@ func (c *Client) AnalysisHints() string {
 	return `Azure Pipelines specific notes:
 - IMPORTANT: Call get_test_results FIRST before reading any logs. It returns structured test failures with error messages and stack traces directly from Azure's Test Results API.
 - Use job logs only for additional context after reviewing structured test results.
-- Pipeline definition files are typically in the repo root or a pipelines/ directory.`
+- Pipeline definition files are typically in the repo root or a pipelines/ directory.
+- If a test file path from stack traces is not found in this repository, the tool will automatically search additional repositories used by this pipeline.`
 }
 
 // Internal types for JSON deserialization of Azure DevOps API responses.
@@ -86,6 +94,7 @@ type build struct {
 	Reason        string `json:"reason"`
 	QueueTime     string `json:"queueTime"`
 	Definition    struct {
+		ID   int    `json:"id"`
 		Name string `json:"name"`
 		Path string `json:"path"`
 	} `json:"definition"`
@@ -612,4 +621,114 @@ func (c *Client) doRequest(ctx context.Context, reqURL string, result interface{
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)
+}
+
+// CrossRepoProvider implementation
+
+// GetFileFromRepo fetches a file from a specific repository, potentially
+// in a different project than the client's primary project.
+func (c *Client) GetFileFromRepo(ctx context.Context, repo ci.RepoRef, filePath string) (string, error) {
+	project := repo.Project
+	if project == "" {
+		project = c.project
+	}
+	repoName := repo.Repo
+	if repoName == "" {
+		repoName = project
+	}
+
+	params := url.Values{
+		"path":        {filePath},
+		"$format":     {"text"},
+		apiVersionKey: {apiVersionValue},
+	}
+	apiURL := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/items?%s",
+		c.baseURL, project, repoName, params.Encode())
+
+	req, err := c.newAPIRequest(ctx, apiURL)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("file not found: %d %s (repo: %s/%s)", resp.StatusCode, filePath, project, repoName)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// DiscoverRepos returns additional repositories used by the build pipeline.
+// Results are cached — subsequent calls for any buildID return the cached list.
+func (c *Client) DiscoverRepos(ctx context.Context, buildID int64) ([]ci.RepoRef, error) {
+	if c.reposDiscovered {
+		return c.discoveredRepos, nil
+	}
+	c.reposDiscovered = true
+
+	// Start with any pre-seeded repos from --test-repo flag
+	c.discoveredRepos = append([]ci.RepoRef{}, c.ExtraRepos...)
+
+	// Get build to find definition ID
+	apiURL := fmt.Sprintf("%s/%s/_apis/build/builds/%d?%s=%s", c.baseURL, c.project, buildID, apiVersionKey, apiVersionValue)
+	var b build
+	if err := c.doRequest(ctx, apiURL, &b); err != nil {
+		return c.discoveredRepos, nil // non-fatal: return what we have
+	}
+
+	if b.Definition.ID == 0 {
+		return c.discoveredRepos, nil
+	}
+
+	// Get definition resources
+	resURL := fmt.Sprintf("%s/%s/_apis/build/definitions/%d/resources?%s=%s",
+		c.baseURL, c.project, b.Definition.ID, apiVersionKey, apiVersionValue+"-preview.1")
+
+	var resources struct {
+		Resources []struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"resources"`
+	}
+	if err := c.doRequest(ctx, resURL, &resources); err != nil {
+		return c.discoveredRepos, nil // non-fatal
+	}
+
+	seen := make(map[string]bool)
+	for _, r := range c.discoveredRepos {
+		seen[r.Project+"/"+r.Repo] = true
+	}
+
+	for _, r := range resources.Resources {
+		if r.Type != "repository" {
+			continue
+		}
+		// Resource ID format: "project/repo" or just "repo" (same project)
+		project, repo := c.project, r.ID
+		if parts := strings.SplitN(r.ID, "/", 2); len(parts) == 2 {
+			project = parts[0]
+			repo = parts[1]
+		}
+		// Skip primary repo
+		if project == c.project && repo == c.project {
+			continue
+		}
+		key := project + "/" + repo
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		c.discoveredRepos = append(c.discoveredRepos, ci.RepoRef{Project: project, Repo: repo})
+	}
+
+	return c.discoveredRepos, nil
 }

--- a/pkg/azure/client_test.go
+++ b/pkg/azure/client_test.go
@@ -16,6 +16,7 @@ import (
 
 // Compile-time interface checks
 var _ ci.Provider = (*Client)(nil)
+var _ ci.CrossRepoProvider = (*Client)(nil)
 var _ ci.TestResultsProvider = (*Client)(nil)
 
 func TestName(t *testing.T) {
@@ -573,4 +574,122 @@ func buildTestZip(t *testing.T, name string, content []byte) []byte {
 	}
 	require.NoError(t, w.Close())
 	return buf.Bytes()
+}
+
+func TestGetFileFromRepo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify it hits a DIFFERENT project/repo than the client's own
+		assert.Contains(t, r.URL.Path, "/other-project/_apis/git/repositories/other-repo/items")
+		assert.Equal(t, "src/Test.java", r.URL.Query().Get("path"))
+		w.Write([]byte("public class Test {}"))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("myorg", "myproject", srv.URL, srv.Client())
+	content, err := c.GetFileFromRepo(context.Background(), ci.RepoRef{Project: "other-project", Repo: "other-repo"}, "src/Test.java")
+	require.NoError(t, err)
+	assert.Equal(t, "public class Test {}", content)
+}
+
+func TestGetFileFromRepo_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("myorg", "myproject", srv.URL, srv.Client())
+	_, err := c.GetFileFromRepo(context.Background(), ci.RepoRef{Project: "other", Repo: "other"}, "missing.java")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestDiscoverRepos(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/builds/100") && !strings.Contains(r.URL.Path, "/timeline") && !strings.Contains(r.URL.Path, "/artifacts") && !strings.Contains(r.URL.Path, "/logs") {
+			w.Write([]byte(`{"id":100,"definition":{"id":42,"name":"CI","path":"\\"}}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/definitions/42/resources") {
+			w.Write([]byte(`{"resources":[
+				{"type":"repository","id":"e2e-tests/e2e-tests"},
+				{"type":"repository","id":"myproject"},
+				{"type":"endpoint","id":"some-connection"}
+			]}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("myorg", "myproject", srv.URL, srv.Client())
+	repos, err := c.DiscoverRepos(context.Background(), 100)
+	require.NoError(t, err)
+	assert.Len(t, repos, 1) // myproject (self) skipped, endpoint skipped
+	assert.Equal(t, "e2e-tests", repos[0].Project)
+	assert.Equal(t, "e2e-tests", repos[0].Repo)
+}
+
+func TestDiscoverRepos_NoExtraRepos(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/builds/200") {
+			w.Write([]byte(`{"id":200,"definition":{"id":10,"name":"CI","path":"\\"}}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/definitions/10/resources") {
+			w.Write([]byte(`{"resources":[{"type":"repository","id":"myproject"}]}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("myorg", "myproject", srv.URL, srv.Client())
+	repos, err := c.DiscoverRepos(context.Background(), 200)
+	require.NoError(t, err)
+	assert.Empty(t, repos)
+}
+
+func TestDiscoverRepos_WithExtraRepos(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/builds/300") {
+			w.Write([]byte(`{"id":300,"definition":{"id":5,"name":"CI","path":"\\"}}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/definitions/5/resources") {
+			w.Write([]byte(`{"resources":[]}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("myorg", "myproject", srv.URL, srv.Client())
+	c.ExtraRepos = []ci.RepoRef{{Project: "other", Repo: "tests"}}
+	repos, err := c.DiscoverRepos(context.Background(), 300)
+	require.NoError(t, err)
+	assert.Len(t, repos, 1)
+	assert.Equal(t, "tests", repos[0].Repo)
+}
+
+func TestDiscoverRepos_Cached(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if strings.Contains(r.URL.Path, "/builds/100") {
+			w.Write([]byte(`{"id":100,"definition":{"id":1}}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/definitions/") {
+			w.Write([]byte(`{"resources":[]}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("myorg", "myproject", srv.URL, srv.Client())
+	_, _ = c.DiscoverRepos(context.Background(), 100)
+	firstCallCount := callCount
+	_, _ = c.DiscoverRepos(context.Background(), 100)
+	assert.Equal(t, firstCallCount, callCount) // second call should be cached — no new API calls
 }

--- a/pkg/ci/ci.go
+++ b/pkg/ci/ci.go
@@ -151,6 +151,22 @@ type TestRun struct {
 	FailedTests int
 }
 
+// CrossRepoProvider is an optional capability for CI platforms that can
+// discover and access files from additional repositories used by a build
+// pipeline (e.g., test repos checked out via resources.repositories).
+type CrossRepoProvider interface {
+	// DiscoverRepos returns additional repository references used by the build pipeline.
+	DiscoverRepos(ctx context.Context, buildID int64) ([]RepoRef, error)
+	// GetFileFromRepo fetches a file from a specific repository.
+	GetFileFromRepo(ctx context.Context, repo RepoRef, path string) (string, error)
+}
+
+// RepoRef identifies a repository within a CI platform.
+type RepoRef struct {
+	Project string // Azure: project name; GitHub: owner
+	Repo    string // repository name or ID
+}
+
 // TestResult represents a single test result.
 type TestResult struct {
 	ID           int64

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -216,10 +216,19 @@ Bug location classification:
   - Only CI config changed → bug_location="infrastructure"
   - No diff available → rely on logs and stack traces alone
 
-  Choose "test" when: stack trace is entirely in test files, expected value is outdated, assertion is brittle.
-  Choose "production" when: stack trace shows exception in app code, actual values indicate logic bug, PR changed production files.
-  Choose "infrastructure" when: logs show ECONNREFUSED, missing tables, empty DB, failed migrations, many unrelated tests fail similarly.
-  Priority: infrastructure → production → test → unknown (smallest scope that explains the failure).
+  CRITICAL: Before classifying bug_location, you MUST read the test source file using get_repo_file.
+  Do not classify based on logs alone — browser console errors (403, 404, 500, 503) do NOT
+  automatically mean infrastructure. Tests may be failing because they don't handle expected
+  error states, have wrong selectors, missing waits, or race conditions.
+
+  Choose "test" when: test code has wrong selectors, missing waits, brittle assertions,
+    doesn't handle expected app states, or fails even when the error condition is benign.
+  Choose "production" when: stack trace shows exception in app code, actual values indicate
+    logic bug, PR changed production files.
+  Choose "infrastructure" when: services are completely unreachable (ECONNREFUSED, DNS failure),
+    DB missing/empty, CI agent misconfiguration. HTTP 4xx/5xx in browser console alone is NOT
+    sufficient — the app may intentionally handle these errors.
+  Priority: Gather evidence first, classify last. Read test source before deciding.
 
   Set bug_location_confidence:
   - "high": Clear stack trace + file evidence

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -22,6 +22,21 @@ func emit(h ToolExecutor, ev ProgressEvent) {
 	}
 }
 
+// formatModelContent serializes a model response Content for debug logging.
+func formatModelContent(c Content) string {
+	var parts []string
+	for _, p := range c.Parts {
+		if p.Text != "" {
+			parts = append(parts, "[text] "+p.Text)
+		}
+		if p.FunctionCall != nil {
+			args, _ := json.Marshal(p.FunctionCall.Args)
+			parts = append(parts, fmt.Sprintf("[call] %s(%s)", p.FunctionCall.Name, string(args)))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 const maxIterations = 30
 const softLimitIteration = 15
 const circuitBreakerThreshold = 3 // consecutive file reads before breaker fires
@@ -308,6 +323,10 @@ func (c *Client) RunAgentLoop(ctx context.Context, handler ToolExecutor, toolDec
 		calledTools: make(map[string]bool),
 	}
 
+	// Debug: emit system prompt and initial context
+	emit(handler, ProgressEvent{Type: "system_prompt", Content: system.Parts[0].Text})
+	emit(handler, ProgressEvent{Type: "initial_context", Content: initialContext})
+
 	for i := range maxIterations {
 		si := &stepInfo{step: i + 1, iteration: i, verbose: verbose}
 
@@ -331,6 +350,9 @@ func (c *Client) RunAgentLoop(ctx context.Context, handler ToolExecutor, toolDec
 		modelContent := candidate.Content
 		modelContent.Role = "model"
 		s.history = append(s.history, modelContent)
+
+		// Debug: emit full model response
+		emit(handler, ProgressEvent{Type: "model_response", Step: si.step, Content: formatModelContent(modelContent)})
 
 		result, err := c.processResponse(ctx, s, handler, modelContent, si)
 		if err != nil {
@@ -557,7 +579,7 @@ func (c *Client) executeCalls(ctx context.Context, s *loopState, handler ToolExe
 	done := false
 	for ci, call := range calls {
 		toolEvent := ProgressEvent{Type: "tool", Step: si.step, MaxStep: maxIterations, Tool: call.Name}
-		if si.verbose && len(call.Args) > 0 {
+		if len(call.Args) > 0 {
 			argsJSON, _ := json.Marshal(call.Args)
 			toolEvent.Args = string(argsJSON)
 		}
@@ -622,6 +644,7 @@ func (s *loopState) interceptCircuitBreaker(call FunctionCall, handler ToolExecu
 
 	if isFileRead && s.consecutiveFileReads > circuitBreakerThreshold && handler.HasTestArtifacts() {
 		s.fileToolsHiddenUntil = si.iteration + circuitBreakerCooldown
+		emit(handler, ProgressEvent{Type: "loop_state", Step: si.step, Message: fmt.Sprintf("circuit breaker: hiding file tools for %d iterations", circuitBreakerCooldown)})
 		return `{"error": "CIRCUIT_BREAKER: You have fetched multiple source files consecutively. File reading is temporarily disabled. Use get_artifact, get_job_logs, or get_test_traces to analyze test failures, then call done with your diagnosis."}`
 	}
 	return ""
@@ -651,17 +674,16 @@ func filterFileTools(tools []Tool) []Tool {
 	return result
 }
 
-// emitToolResult sends a verbose progress event for a completed tool call.
+// emitToolResult sends a progress event for a completed tool call.
+// In verbose mode, it's displayed on stderr. In debug mode, full content is logged to file.
 func emitToolResult(handler ToolExecutor, si *stepInfo, ci, totalCalls, toolMs int, result string) {
-	if !si.verbose {
-		return
-	}
 	ev := ProgressEvent{
 		Type:    "result",
 		Step:    si.step,
 		MaxStep: maxIterations,
 		Chars:   len(result),
 		ToolMs:  toolMs,
+		Content: result, // full content for debug logging
 	}
 	// Attach model stats to the last tool call in this step
 	if ci == totalCalls-1 {

--- a/pkg/llm/debug.go
+++ b/pkg/llm/debug.go
@@ -1,0 +1,83 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// debugLine is the JSONL structure written to the debug log file.
+type debugLine struct {
+	Timestamp string `json:"ts"`
+	Type      string `json:"type"`
+	Step      int    `json:"step,omitempty"`
+	MaxStep   int    `json:"max,omitempty"`
+	Tool      string `json:"tool,omitempty"`
+	Args      string `json:"args,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Content   string `json:"content,omitempty"`
+	ModelMs   int    `json:"model_ms,omitempty"`
+	Tokens    int    `json:"tokens,omitempty"`
+	Chars     int    `json:"chars,omitempty"`
+	ToolMs    int    `json:"tool_ms,omitempty"`
+}
+
+// DebugEmitter wraps a ProgressEmitter and writes all events as JSONL to a file.
+// It forwards every event to the inner emitter for normal display, and additionally
+// writes the full event (including Content) to the debug log.
+type DebugEmitter struct {
+	inner ProgressEmitter
+	file  *os.File
+	enc   *json.Encoder
+	mu    sync.Mutex
+}
+
+// NewDebugEmitter creates a DebugEmitter that wraps the given inner emitter.
+// It creates a temporary JSONL file for debug output.
+func NewDebugEmitter(inner ProgressEmitter) (*DebugEmitter, error) {
+	f, err := os.CreateTemp("", "heisenberg-debug-*.jsonl")
+	if err != nil {
+		return nil, fmt.Errorf("creating debug log: %w", err)
+	}
+	return &DebugEmitter{
+		inner: inner,
+		file:  f,
+		enc:   json.NewEncoder(f),
+	}, nil
+}
+
+// Emit forwards the event to the inner emitter and writes it to the debug log.
+func (d *DebugEmitter) Emit(ev ProgressEvent) {
+	d.inner.Emit(ev)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_ = d.enc.Encode(debugLine{
+		Timestamp: time.Now().Format(time.RFC3339Nano),
+		Type:      ev.Type,
+		Step:      ev.Step,
+		MaxStep:   ev.MaxStep,
+		Tool:      ev.Tool,
+		Args:      ev.Args,
+		Message:   ev.Message,
+		Content:   ev.Content,
+		ModelMs:   ev.ModelMs,
+		Tokens:    ev.Tokens,
+		Chars:     ev.Chars,
+		ToolMs:    ev.ToolMs,
+	})
+}
+
+// Path returns the path to the debug log file.
+func (d *DebugEmitter) Path() string {
+	return d.file.Name()
+}
+
+// Close flushes and closes the debug log file.
+func (d *DebugEmitter) Close() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_ = d.file.Close()
+}

--- a/pkg/llm/debug_test.go
+++ b/pkg/llm/debug_test.go
@@ -1,0 +1,102 @@
+package llm
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type captureEmitter struct {
+	events []ProgressEvent
+}
+
+func (c *captureEmitter) Emit(ev ProgressEvent) {
+	c.events = append(c.events, ev)
+}
+
+func TestDebugEmitter_WritesJSONL(t *testing.T) {
+	inner := &captureEmitter{}
+	d, err := NewDebugEmitter(inner)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(d.Path()) }()
+
+	d.Emit(ProgressEvent{Type: "system_prompt", Content: "You are an expert..."})
+	d.Emit(ProgressEvent{Type: "tool", Step: 1, MaxStep: 30, Tool: "get_job_logs", Args: `{"job_id":123}`})
+	d.Emit(ProgressEvent{Type: "tool_result", Step: 1, Tool: "get_job_logs", Chars: 80000, Content: "full log content here..."})
+	d.Emit(ProgressEvent{Type: "model_response", Step: 2, Content: "Based on the logs, I can see..."})
+	d.Close()
+
+	// Verify inner emitter received all events
+	assert.Len(t, inner.events, 4)
+	assert.Equal(t, "system_prompt", inner.events[0].Type)
+	assert.Equal(t, "tool", inner.events[1].Type)
+
+	// Verify JSONL file
+	f, err := os.Open(d.Path())
+	require.NoError(t, err)
+	defer f.Close()
+
+	var lines []debugLine
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // handle large lines
+	for scanner.Scan() {
+		var line debugLine
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &line))
+		lines = append(lines, line)
+	}
+	require.NoError(t, scanner.Err())
+
+	assert.Len(t, lines, 4)
+
+	// system_prompt
+	assert.Equal(t, "system_prompt", lines[0].Type)
+	assert.Equal(t, "You are an expert...", lines[0].Content)
+	assert.NotEmpty(t, lines[0].Timestamp)
+
+	// tool call
+	assert.Equal(t, "tool", lines[1].Type)
+	assert.Equal(t, "get_job_logs", lines[1].Tool)
+	assert.Equal(t, `{"job_id":123}`, lines[1].Args)
+
+	// tool result with full content
+	assert.Equal(t, "tool_result", lines[2].Type)
+	assert.Equal(t, 80000, lines[2].Chars)
+	assert.Equal(t, "full log content here...", lines[2].Content)
+
+	// model response
+	assert.Equal(t, "model_response", lines[3].Type)
+	assert.Equal(t, "Based on the logs, I can see...", lines[3].Content)
+}
+
+func TestDebugEmitter_Path(t *testing.T) {
+	inner := &captureEmitter{}
+	d, err := NewDebugEmitter(inner)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(d.Path()) }()
+	defer d.Close()
+
+	path := d.Path()
+	assert.Contains(t, path, "heisenberg-debug-")
+	assert.Contains(t, path, ".jsonl")
+
+	// File should exist
+	_, err = os.Stat(path)
+	assert.NoError(t, err)
+}
+
+func TestDebugEmitter_ForwardsToInner(t *testing.T) {
+	inner := &captureEmitter{}
+	d, err := NewDebugEmitter(inner)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(d.Path()) }()
+	defer d.Close()
+
+	d.Emit(ProgressEvent{Type: "info", Message: "test message"})
+	assert.Len(t, inner.events, 1)
+	assert.Equal(t, "info", inner.events[0].Type)
+	assert.Equal(t, "test message", inner.events[0].Message)
+}

--- a/pkg/llm/progress.go
+++ b/pkg/llm/progress.go
@@ -29,6 +29,7 @@ type ProgressEvent struct {
 	Tokens   int             `json:"tokens,omitempty"`   // prompt token count
 	Chars    int             `json:"chars,omitempty"`    // tool result size in characters
 	ToolMs   int             `json:"tool_ms,omitempty"`  // tool execution duration in ms
+	Content  string          `json:"-"`                  // full content for debug logging (ignored by TextEmitter)
 }
 
 // ProgressEmitter receives progress events during analysis.

--- a/scripts/action-entrypoint.sh
+++ b/scripts/action-entrypoint.sh
@@ -5,7 +5,7 @@ REPO="${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}"
 # Docker actions set INPUT_RUN-ID (with hyphen), bash can't reference that directly
 RUN_ID=$(printenv 'INPUT_RUN-ID' 2>/dev/null || echo "")
 
-CMD=("heisenberg" "$REPO" "--format" "json")
+CMD=("heisenberg" "analyze" "$REPO" "--format" "json")
 [[ -n "$RUN_ID" ]] && CMD+=("--run-id" "$RUN_ID")
 
 # Run and capture JSON (allow non-zero exit — structured errors are still valid JSON)

--- a/scripts/e2e-snapshot.sh
+++ b/scripts/e2e-snapshot.sh
@@ -35,7 +35,7 @@ for entry in "${REPOS[@]}"; do
   SLUG="${REPO//\//_}_${RUN_ID}"
   echo -n "  $REPO #$RUN_ID ... "
 
-  if "$BINARY" --json --model "$MODEL" "$REPO" --run-id "$RUN_ID" \
+  if "$BINARY" analyze --format json --model "$MODEL" "$REPO" --run-id "$RUN_ID" \
     2>"$DIR/${SLUG}.stderr" > "$DIR/${SLUG}.json"; then
     CATEGORY=$(jq -r '.category' "$DIR/${SLUG}.json")
     COUNT=$(jq '.analyses | length' "$DIR/${SLUG}.json")


### PR DESCRIPTION
## Summary

- Add `CrossRepoProvider` optional interface for discovering and accessing files from additional repositories used by a build pipeline
- Azure client auto-discovers repos from pipeline definition resources API
- `get_repo_file` tool transparently tries other repos on 404 before falling back to directory listing
- New `--test-repo` flag for explicit test repo override

## How it works

1. LLM calls `get_repo_file("com/test/MyTest.java")` → 404 on primary repo
2. Tool handler checks if provider implements `CrossRepoProvider`
3. Calls `DiscoverRepos(buildID)` → fetches pipeline definition resources → finds additional repos
4. Tries `GetFileFromRepo(repo, path)` for each discovered repo
5. If found → returns content. If all fail → falls back to `smartNotFound` (directory listing)

## Test plan

- [x] `TestGetFileFromRepo` — cross-project file access
- [x] `TestDiscoverRepos` — pipeline definition parsing, self-skip, caching
- [x] `TestGetRepoFile_CrossRepoFallback` — end-to-end via tool handler
- [x] `TestGetRepoFile_CrossRepoAllFail` — graceful fallback
- [x] `go test ./...` passes
- [ ] Live test against contoso/example-plugin build with E2E tests in separate repo