### PR TITLE
fix: validate run status before analysis

### DIFF
--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -33,7 +33,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 	// Resolve run ID
 	if p.RunID == 0 {
 		emitInfo(p.Emitter, fmt.Sprintf("Finding run to analyze for %s/%s...", p.Owner, p.Repo))
-		runs, err := p.CI.ListRuns(ctx, ci.RunFilter{Status: "completed", PerPage: 10})
+		runs, err := p.CI.ListRuns(ctx, ci.RunFilter{Status: ci.StatusCompleted, PerPage: 10})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list runs: %w", err)
 		}
@@ -274,7 +274,7 @@ func fetchFailureLogs(ctx context.Context, p Params, failedJobs []ci.Job) []clus
 func filterFailed(jobs []ci.Job) []ci.Job {
 	var failed []ci.Job
 	for _, j := range jobs {
-		if j.Conclusion == "failure" {
+		if j.Conclusion == ci.ConclusionFailure {
 			failed = append(failed, j)
 		}
 	}
@@ -375,9 +375,9 @@ func validateRunStatus(run *ci.Run, jobs []ci.Job) error {
 	if run.Status == "" || run.IsCompleted() {
 		return nil
 	}
-	if run.Status == "in_progress" {
+	if run.Status == ci.StatusInProgress {
 		for _, j := range jobs {
-			if j.Status == "completed" && j.Conclusion == "failure" {
+			if j.Status == ci.StatusCompleted && j.Conclusion == ci.ConclusionFailure {
 				return nil
 			}
 		}
@@ -457,13 +457,13 @@ func findRunToAnalyze(runs []ci.Run) (runID int64, shouldSkip bool) {
 
 	// Check if the latest completed run is a success
 	latest := runs[0]
-	if latest.Conclusion == "success" {
+	if latest.Conclusion == ci.ConclusionSuccess {
 		return 0, true
 	}
 
 	// Find the first failure
 	for _, r := range runs {
-		if r.Conclusion == "failure" {
+		if r.Conclusion == ci.ConclusionFailure {
 			return r.ID, false
 		}
 	}

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -66,6 +66,14 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 		return nil, fmt.Errorf("failed to list jobs: %w", err)
 	}
 
+	// Validate run has completed or has actionable failed jobs.
+	// In-progress runs are allowed if they have completed failed jobs (e.g.,
+	// Azure builds waiting for manual approval on later stages, or GitHub
+	// matrix builds where some jobs have failed while others are still running).
+	if err := validateRunStatus(ciRun, jobs); err != nil {
+		return nil, err
+	}
+
 	artifacts, err := p.CI.ListArtifacts(ctx, p.RunID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list artifacts: %w", err)
@@ -358,6 +366,24 @@ func stampRunMeta(result *llm.AnalysisResult, p Params, ciRun *ci.Run) {
 	result.Branch = ciRun.Branch
 	result.CommitSHA = ciRun.CommitSHA
 	result.Event = ciRun.Event
+}
+
+// validateRunStatus returns an error if the run lacks actionable failure data.
+// Allows in-progress runs if they have at least one completed failed job (e.g.,
+// Azure builds pending manual approval, GitHub matrix builds with partial failures).
+func validateRunStatus(run *ci.Run, jobs []ci.Job) error {
+	if run.Status == "" || run.IsCompleted() {
+		return nil
+	}
+	if run.Status == "in_progress" {
+		for _, j := range jobs {
+			if j.Status == "completed" && j.Conclusion == "failure" {
+				return nil
+			}
+		}
+		return fmt.Errorf("run %d is still in progress and has no completed failed jobs — wait for it to complete before analyzing", run.ID)
+	}
+	return fmt.Errorf("run %d is not yet completed (status: %s)", run.ID, run.Status)
 }
 
 func emitInfo(e llm.ProgressEmitter, msg string) {

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -16,10 +16,13 @@ import (
 )
 
 const (
-	htmlReportName  = "html-report"
-	testReportLabel = "TEST REPORT"
-	e2eJobName      = "E2E 1/4"
-	testRunDate     = "2026-02-08"
+	htmlReportName     = "html-report"
+	testReportLabel    = "TEST REPORT"
+	e2eJobName         = "E2E 1/4"
+	testRunDate        = "2026-02-08"
+	testRunPath        = "/repos/owner/repo/actions/runs/999"
+	testJobsPath       = testRunPath + "/jobs"
+	errStillInProgress = "still in progress"
 )
 
 func TestFormatRunDate_ValidRFC3339(t *testing.T) {
@@ -318,9 +321,9 @@ func TestIsTestArtifact(t *testing.T) {
 func TestRun_RejectsInProgressRunWithNoFailedJobs(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/repos/owner/repo/actions/runs/999":
+		case testRunPath:
 			fmt.Fprint(w, `{"id":999,"status":"in_progress","conclusion":"","head_branch":"main","head_sha":"abc"}`)
-		case "/repos/owner/repo/actions/runs/999/jobs":
+		case testJobsPath:
 			fmt.Fprint(w, `{"jobs":[{"id":1,"name":"build","status":"in_progress","conclusion":""}]}`)
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -337,16 +340,16 @@ func TestRun_RejectsInProgressRunWithNoFailedJobs(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "still in progress")
+	assert.Contains(t, err.Error(), errStillInProgress)
 }
 
 func TestRun_AllowsInProgressRunWithCompletedFailedJobs(t *testing.T) {
 	// Simulates Azure manual approval: test job failed, deploy stage pending
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/repos/owner/repo/actions/runs/999":
+		case testRunPath:
 			fmt.Fprint(w, `{"id":999,"status":"in_progress","conclusion":"","head_branch":"main","head_sha":"abc"}`)
-		case "/repos/owner/repo/actions/runs/999/jobs":
+		case testJobsPath:
 			fmt.Fprint(w, `{"jobs":[
 				{"id":1,"name":"test","status":"completed","conclusion":"failure"},
 				{"id":2,"name":"deploy","status":"queued","conclusion":""}
@@ -379,9 +382,9 @@ func TestRun_AllowsInProgressRunWithCompletedFailedJobs(t *testing.T) {
 func TestRun_RejectsQueuedRun(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/repos/owner/repo/actions/runs/999":
+		case testRunPath:
 			fmt.Fprint(w, `{"id":999,"status":"queued","conclusion":"","head_branch":"main","head_sha":"abc"}`)
-		case "/repos/owner/repo/actions/runs/999/jobs":
+		case testJobsPath:
 			fmt.Fprint(w, `{"jobs":[]}`)
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -431,7 +434,7 @@ func TestValidateRunStatus(t *testing.T) {
 	t.Run("in_progress with no jobs is rejected", func(t *testing.T) {
 		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, nil)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "still in progress")
+		assert.Contains(t, err.Error(), errStillInProgress)
 	})
 
 	t.Run("in_progress with completed failed job is allowed", func(t *testing.T) {
@@ -449,7 +452,7 @@ func TestValidateRunStatus(t *testing.T) {
 		}
 		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, jobs)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "still in progress")
+		assert.Contains(t, err.Error(), errStillInProgress)
 	})
 
 	t.Run("in_progress with completed success jobs only is rejected", func(t *testing.T) {
@@ -459,7 +462,7 @@ func TestValidateRunStatus(t *testing.T) {
 		}
 		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, jobs)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "still in progress")
+		assert.Contains(t, err.Error(), errStillInProgress)
 	})
 
 	t.Run("queued run is rejected", func(t *testing.T) {

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -315,6 +315,160 @@ func TestIsTestArtifact(t *testing.T) {
 	assert.False(t, isTestArtifact("coverage.out"))
 }
 
+func TestRun_RejectsInProgressRunWithNoFailedJobs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/actions/runs/999":
+			fmt.Fprint(w, `{"id":999,"status":"in_progress","conclusion":"","head_branch":"main","head_sha":"abc"}`)
+		case "/repos/owner/repo/actions/runs/999/jobs":
+			fmt.Fprint(w, `{"jobs":[{"id":1,"name":"build","status":"in_progress","conclusion":""}]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient("owner", "repo", srv.URL, srv.Client())
+	_, err := Run(context.Background(), Params{
+		Owner: "owner",
+		Repo:  "repo",
+		RunID: 999,
+		CI:    ghClient,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still in progress")
+}
+
+func TestRun_AllowsInProgressRunWithCompletedFailedJobs(t *testing.T) {
+	// Simulates Azure manual approval: test job failed, deploy stage pending
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/actions/runs/999":
+			fmt.Fprint(w, `{"id":999,"status":"in_progress","conclusion":"","head_branch":"main","head_sha":"abc"}`)
+		case "/repos/owner/repo/actions/runs/999/jobs":
+			fmt.Fprint(w, `{"jobs":[
+				{"id":1,"name":"test","status":"completed","conclusion":"failure"},
+				{"id":2,"name":"deploy","status":"queued","conclusion":""}
+			]}`)
+		case "/repos/owner/repo/actions/runs/999/artifacts":
+			fmt.Fprint(w, `{"artifacts":[]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient("owner", "repo", srv.URL, srv.Client())
+	// Run() should NOT return an error — the run has actionable failures
+	_, err := Run(context.Background(), Params{
+		Owner:        "owner",
+		Repo:         "repo",
+		RunID:        999,
+		CI:           ghClient,
+		GoogleAPIKey: "fake", // needed to create LLM client
+	})
+
+	// The run should pass validation. It will fail later (no real LLM key),
+	// but the error should NOT be about "in progress".
+	if err != nil {
+		assert.NotContains(t, err.Error(), "in progress")
+	}
+}
+
+func TestRun_RejectsQueuedRun(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/actions/runs/999":
+			fmt.Fprint(w, `{"id":999,"status":"queued","conclusion":"","head_branch":"main","head_sha":"abc"}`)
+		case "/repos/owner/repo/actions/runs/999/jobs":
+			fmt.Fprint(w, `{"jobs":[]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := gh.NewTestClient("owner", "repo", srv.URL, srv.Client())
+	_, err := Run(context.Background(), Params{
+		Owner: "owner",
+		Repo:  "repo",
+		RunID: 999,
+		CI:    ghClient,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet completed")
+}
+
+func TestRunIsCompleted(t *testing.T) {
+	tests := []struct {
+		status    string
+		completed bool
+	}{
+		{"completed", true},
+		{"in_progress", false},
+		{"queued", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		r := &ci.Run{Status: tt.status}
+		assert.Equal(t, tt.completed, r.IsCompleted(), "status=%q", tt.status)
+	}
+}
+
+func TestValidateRunStatus(t *testing.T) {
+	t.Run("completed run is allowed", func(t *testing.T) {
+		err := validateRunStatus(&ci.Run{ID: 1, Status: "completed"}, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty status is allowed (legacy provider)", func(t *testing.T) {
+		err := validateRunStatus(&ci.Run{ID: 1, Status: ""}, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("in_progress with no jobs is rejected", func(t *testing.T) {
+		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "still in progress")
+	})
+
+	t.Run("in_progress with completed failed job is allowed", func(t *testing.T) {
+		jobs := []ci.Job{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure"},
+			{ID: 2, Name: "deploy", Status: "queued", Conclusion: ""},
+		}
+		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, jobs)
+		assert.NoError(t, err)
+	})
+
+	t.Run("in_progress with only running jobs is rejected", func(t *testing.T) {
+		jobs := []ci.Job{
+			{ID: 1, Name: "build", Status: "in_progress", Conclusion: ""},
+		}
+		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, jobs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "still in progress")
+	})
+
+	t.Run("in_progress with completed success jobs only is rejected", func(t *testing.T) {
+		jobs := []ci.Job{
+			{ID: 1, Name: "build", Status: "completed", Conclusion: "success"},
+			{ID: 2, Name: "test", Status: "in_progress", Conclusion: ""},
+		}
+		err := validateRunStatus(&ci.Run{ID: 1, Status: "in_progress"}, jobs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "still in progress")
+	})
+
+	t.Run("queued run is rejected", func(t *testing.T) {
+		err := validateRunStatus(&ci.Run{ID: 1, Status: "queued"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet completed")
+	})
+}
+
 func TestFetchFailureLogs(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Return different logs per job

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -288,7 +288,7 @@ func (c *Client) ListJobs(ctx context.Context, runID int64) ([]ci.Job, error) {
 		jobs = append(jobs, ci.Job{
 			ID:         encodeJobID(runID, logID),
 			Name:       r.Name,
-			Status:     r.State,
+			Status:     mapStatus(r.State),
 			Conclusion: mapResult(r.Result),
 		})
 	}

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -130,13 +130,11 @@ func (b *build) toCIRun() ci.Run {
 func mapStatus(status string) string {
 	switch status {
 	case "completed":
-		return "completed"
-	case "inProgress":
-		return "in_progress"
+		return ci.StatusCompleted
+	case "inProgress", "cancelling":
+		return ci.StatusInProgress
 	case "notStarted", "postponed", "none":
-		return "queued"
-	case "cancelling":
-		return "in_progress"
+		return ci.StatusQueued
 	default:
 		return status
 	}
@@ -145,9 +143,9 @@ func mapStatus(status string) string {
 func mapResult(result string) string {
 	switch result {
 	case "succeeded":
-		return "success"
+		return ci.ConclusionSuccess
 	case "failed", "partiallySucceeded":
-		return "failure"
+		return ci.ConclusionFailure
 	case "canceled":
 		return "cancelled"
 	default:

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -106,6 +106,7 @@ func (b *build) toCIRun() ci.Run {
 	run := ci.Run{
 		ID:           int64(b.ID),
 		Name:         b.Definition.Name,
+		Status:       mapStatus(b.Status),
 		Conclusion:   mapResult(b.Result),
 		Branch:       stripBranchPrefix(b.SourceBranch),
 		CommitSHA:    b.SourceVersion,
@@ -122,6 +123,23 @@ func (b *build) toCIRun() ci.Run {
 	}
 
 	return run
+}
+
+// mapStatus normalizes Azure build status to ci.Run status values.
+// Azure statuses: all, cancelling, completed, inProgress, none, notStarted, postponed
+func mapStatus(status string) string {
+	switch status {
+	case "completed":
+		return "completed"
+	case "inProgress":
+		return "in_progress"
+	case "notStarted", "postponed", "none":
+		return "queued"
+	case "cancelling":
+		return "in_progress"
+	default:
+		return status
+	}
 }
 
 func mapResult(result string) string {

--- a/pkg/azure/client_test.go
+++ b/pkg/azure/client_test.go
@@ -524,6 +524,44 @@ func TestExtractFirstFile_Empty(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMapStatus(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"completed", "completed"},
+		{"inProgress", "in_progress"},
+		{"notStarted", "queued"},
+		{"postponed", "queued"},
+		{"none", "queued"},
+		{"cancelling", "in_progress"},
+		{"other", "other"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, mapStatus(tt.in), "mapStatus(%q)", tt.in)
+	}
+}
+
+func TestGetRun_MapsStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": 789,
+			"buildNumber": "20260402.1",
+			"status": "inProgress",
+			"result": "",
+			"sourceBranch": "refs/heads/main",
+			"sourceVersion": "abc",
+			"reason": "manual",
+			"queueTime": "2026-04-02T10:00:00Z",
+			"definition": {"name": "CI", "path": "\\pipelines"}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("org", "proj", srv.URL, srv.Client())
+	run, err := c.GetRun(context.Background(), 789)
+	require.NoError(t, err)
+	assert.Equal(t, "in_progress", run.Status)
+	assert.False(t, run.IsCompleted())
+}
+
 func TestMapResult(t *testing.T) {
 	tests := []struct{ in, want string }{
 		{"succeeded", "success"},

--- a/pkg/azure/client_test.go
+++ b/pkg/azure/client_test.go
@@ -524,6 +524,25 @@ func TestExtractFirstFile_Empty(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestListJobs_NormalizesStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"records": [
+				{"id": "j1", "type": "Job", "name": "running-job", "state": "inProgress", "result": "", "log": {"id": 1}},
+				{"id": "j2", "type": "Job", "name": "done-job", "state": "completed", "result": "succeeded", "log": {"id": 2}}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("org", "proj", srv.URL, srv.Client())
+	jobs, err := c.ListJobs(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+	assert.Equal(t, ci.StatusInProgress, jobs[0].Status, "Azure inProgress should normalize to in_progress")
+	assert.Equal(t, ci.StatusCompleted, jobs[1].Status)
+}
+
 func TestMapStatus(t *testing.T) {
 	tests := []struct{ in, want string }{
 		{"completed", "completed"},

--- a/pkg/ci/ci.go
+++ b/pkg/ci/ci.go
@@ -5,6 +5,20 @@ package ci
 
 import "context"
 
+// Normalized run/job status values. CI providers must map platform-specific
+// statuses to these constants (e.g., Azure "inProgress" → StatusInProgress).
+const (
+	StatusCompleted  = "completed"
+	StatusInProgress = "in_progress"
+	StatusQueued     = "queued"
+)
+
+// Normalized conclusion values.
+const (
+	ConclusionSuccess = "success"
+	ConclusionFailure = "failure"
+)
+
 // Provider abstracts CI platform operations needed for test failure analysis.
 // Implementations bind platform-specific identifiers (e.g., owner/repo for GitHub,
 // org/project for Azure DevOps) at construction time.
@@ -80,7 +94,7 @@ type Run struct {
 
 // IsCompleted returns true if the run has finished (not in progress or queued).
 func (r *Run) IsCompleted() bool {
-	return r.Status == "completed"
+	return r.Status == StatusCompleted
 }
 
 // Job represents a unit of work within a CI run.

--- a/pkg/ci/ci.go
+++ b/pkg/ci/ci.go
@@ -67,6 +67,7 @@ type RunFilter struct {
 type Run struct {
 	ID           int64
 	Name         string
+	Status       string // "completed", "in_progress", "queued", etc.
 	Conclusion   string // "success", "failure", etc.
 	Branch       string
 	CommitSHA    string
@@ -75,6 +76,11 @@ type Run struct {
 	DisplayTitle string
 	CreatedAt    string
 	PRNumbers    []int // associated pull request numbers
+}
+
+// IsCompleted returns true if the run has finished (not in progress or queued).
+func (r *Run) IsCompleted() bool {
+	return r.Status == "completed"
 }
 
 // Job represents a unit of work within a CI run.

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -84,6 +84,7 @@ func ClassifyArtifact(name string) ci.ArtifactType {
 type workflowRun struct {
 	ID           int64  `json:"id"`
 	Name         string `json:"name"`
+	Status       string `json:"status"`
 	Conclusion   string `json:"conclusion"`
 	HeadBranch   string `json:"head_branch"`
 	HeadSHA      string `json:"head_sha"`
@@ -100,6 +101,7 @@ func (r *workflowRun) toCIRun() ci.Run {
 	run := ci.Run{
 		ID:           r.ID,
 		Name:         r.Name,
+		Status:       r.Status,
 		Conclusion:   r.Conclusion,
 		Branch:       r.HeadBranch,
 		CommitSHA:    r.HeadSHA,

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -97,12 +97,25 @@ type workflowRun struct {
 	} `json:"pull_requests"`
 }
 
+// mapConclusion normalizes GitHub conclusion values. GitHub uses "timed_out"
+// for jobs that exceed their timeout, which should be treated as a failure.
+func mapConclusion(conclusion string) string {
+	switch conclusion {
+	case "success":
+		return ci.ConclusionSuccess
+	case "failure", "timed_out":
+		return ci.ConclusionFailure
+	default:
+		return conclusion
+	}
+}
+
 func (r *workflowRun) toCIRun() ci.Run {
 	run := ci.Run{
 		ID:           r.ID,
 		Name:         r.Name,
 		Status:       r.Status,
-		Conclusion:   r.Conclusion,
+		Conclusion:   mapConclusion(r.Conclusion),
 		Branch:       r.HeadBranch,
 		CommitSHA:    r.HeadSHA,
 		Event:        r.Event,
@@ -128,7 +141,7 @@ func (j *job) toCIJob() ci.Job {
 		ID:         j.ID,
 		Name:       j.Name,
 		Status:     j.Status,
-		Conclusion: j.Conclusion,
+		Conclusion: mapConclusion(j.Conclusion),
 	}
 }
 

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -231,6 +232,45 @@ func TestGetRun_PullRequests(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, run.PRNumbers, 1)
 	assert.Equal(t, 42, run.PRNumbers[0])
+}
+
+func TestMapConclusion(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"success", ci.ConclusionSuccess},
+		{"failure", ci.ConclusionFailure},
+		{"timed_out", ci.ConclusionFailure},
+		{"cancelled", "cancelled"},
+		{"skipped", "skipped"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, mapConclusion(tt.in), "mapConclusion(%q)", tt.in)
+	}
+}
+
+func TestGetRun_MapsTimedOutConclusion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id":1,"status":"completed","conclusion":"timed_out","head_branch":"main","head_sha":"abc"}`)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("o", "r", srv.URL, srv.Client())
+	run, err := c.GetRun(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, ci.ConclusionFailure, run.Conclusion, "timed_out should map to failure")
+}
+
+func TestListJobs_MapsTimedOutConclusion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"jobs":[{"id":1,"name":"test","status":"completed","conclusion":"timed_out"}]}`)
+	}))
+	defer srv.Close()
+
+	c := NewTestClient("o", "r", srv.URL, srv.Client())
+	jobs, err := c.ListJobs(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, ci.ConclusionFailure, jobs[0].Conclusion, "timed_out job should map to failure")
 }
 
 func TestName(t *testing.T) {


### PR DESCRIPTION
Closes #40

## Summary

- Add `Status` field to `ci.Run` struct, mapped from both GitHub (`status`) and Azure (`status` → normalized)
- Validate run status after `GetRun()` + `ListJobs()` — reject runs with no completed failed jobs
- **Hybrid approach**: allow in-progress runs that have completed failed jobs (Azure manual approval stages, GitHub matrix partial failures)

## Validation logic

| Run status | Jobs | Result |
|---|---|---|
| `completed` | any | Allow |
| `""` (empty) | any | Allow (backward compat) |
| `in_progress` | has completed failed job | Allow |
| `in_progress` | no completed failed jobs | Reject: "still in progress" |
| `queued` | any | Reject: "not yet completed" |

## Test plan
- [x] `TestRun_RejectsInProgressRunWithNoFailedJobs` — no completed jobs → error
- [x] `TestRun_AllowsInProgressRunWithCompletedFailedJobs` — Azure manual approval case → passes validation
- [x] `TestRun_RejectsQueuedRun` — queued run → error
- [x] `TestValidateRunStatus` — 7 subtests covering all combinations
- [x] `TestRunIsCompleted` — `ci.Run.IsCompleted()` helper
- [x] All existing tests pass