### PR TITLE
fix: sort similar RCAs by similarity before truncation

### DIFF
--- a/ee/api/analysis_handlers.go
+++ b/ee/api/analysis_handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -278,25 +279,35 @@ func (s *Server) handleSimilarAnalyses(w http.ResponseWriter, r *http.Request) {
 func (s *Server) collectSimilar(ctx context.Context, orgID, excludeID uuid.UUID,
 	embeddings []database.RCAEmbedding, limit int, threshold float64) []database.SimilarRCA {
 
-	seen := make(map[uuid.UUID]struct{})
-	all := make([]database.SimilarRCA, 0)
+	var all []database.SimilarRCA
 	for _, emb := range embeddings {
 		similar, err := s.db.FindSimilarRCAs(ctx, orgID, emb.Embedding, excludeID, limit, threshold)
 		if err != nil {
 			log.Printf("FindSimilarRCAs failed for embedding %s: %v", emb.ID, err)
 			continue
 		}
-		for _, sr := range similar {
-			if _, exists := seen[sr.ID]; !exists {
-				seen[sr.ID] = struct{}{}
-				all = append(all, sr)
-			}
+		all = append(all, similar...)
+	}
+	return mergeSimilarResults(all, limit)
+}
+
+// mergeSimilarResults deduplicates by ID, sorts by similarity descending, and caps at limit.
+func mergeSimilarResults(results []database.SimilarRCA, limit int) []database.SimilarRCA {
+	seen := make(map[uuid.UUID]struct{})
+	deduped := make([]database.SimilarRCA, 0, len(results))
+	for _, r := range results {
+		if _, exists := seen[r.ID]; !exists {
+			seen[r.ID] = struct{}{}
+			deduped = append(deduped, r)
 		}
 	}
-	if len(all) > limit {
-		all = all[:limit]
+	sort.Slice(deduped, func(i, j int) bool {
+		return deduped[i].Similarity > deduped[j].Similarity
+	})
+	if len(deduped) > limit {
+		deduped = deduped[:limit]
 	}
-	return all
+	return deduped
 }
 
 // handlePatternSearch searches historical patterns by free-text query.

--- a/ee/api/api_test.go
+++ b/ee/api/api_test.go
@@ -92,6 +92,42 @@ func withAuthContext(r *http.Request, userID, email string) *http.Request {
 	return r.WithContext(ctx)
 }
 
+func TestMergeSimilarResults_SortsBySimiliarity(t *testing.T) {
+	id1, id2, id3 := uuid.New(), uuid.New(), uuid.New()
+	results := []database.SimilarRCA{
+		{ID: id1, Similarity: 0.6},
+		{ID: id2, Similarity: 0.9},
+		{ID: id3, Similarity: 0.75},
+	}
+
+	merged := mergeSimilarResults(results, 2)
+
+	require.Len(t, merged, 2)
+	assert.Equal(t, id2, merged[0].ID, "highest similarity first")
+	assert.Equal(t, id3, merged[1].ID, "second highest next")
+}
+
+func TestMergeSimilarResults_Deduplicates(t *testing.T) {
+	id := uuid.New()
+	results := []database.SimilarRCA{
+		{ID: id, Similarity: 0.8},
+		{ID: id, Similarity: 0.9}, // duplicate
+	}
+
+	merged := mergeSimilarResults(results, 10)
+	assert.Len(t, merged, 1, "duplicates should be removed")
+}
+
+func TestMergeSimilarResults_NoTruncation(t *testing.T) {
+	results := []database.SimilarRCA{
+		{ID: uuid.New(), Similarity: 0.8},
+		{ID: uuid.New(), Similarity: 0.6},
+	}
+
+	merged := mergeSimilarResults(results, 10)
+	assert.Len(t, merged, 2, "should not truncate when under limit")
+}
+
 func TestHealthEndpoint(t *testing.T) {
 	db := testDB(t)
 	server := testServer(t, db)


### PR DESCRIPTION
Closes #46

## Summary

- Extract `mergeSimilarResults` from `collectSimilar` — deduplicates by ID, sorts by similarity descending, then truncates to limit
- Prevents high-similarity matches from being silently discarded when multiple embeddings contribute results

## Test plan
- [x] `TestMergeSimilarResults_SortsBySimiliarity` — verifies highest similarity first after truncation
- [x] `TestMergeSimilarResults_Deduplicates` — duplicate IDs removed
- [x] `TestMergeSimilarResults_NoTruncation` — no truncation when under limit
- [x] All existing tests pass