### PR TITLE
feat: confidence calibration — reduce false positives for external root causes

### DIFF
--- a/pkg/analysis/calibrate.go
+++ b/pkg/analysis/calibrate.go
@@ -64,63 +64,62 @@ const (
 	capAmbiguous = 49 // low end of "likely" tier
 )
 
+// capRule holds a confidence ceiling and the reason for applying it.
+type capRule struct {
+	ceiling int
+	reason  string
+}
+
 // applyConfidenceCaps enforces hard confidence ceilings when the LLM's
 // structured output contradicts deterministic pipeline signals.
 func applyConfidenceCaps(result *llm.AnalysisResult, s CalibrationSignals) {
-	cap := 100
-	reason := ""
+	rules := evaluateRules(s)
+
+	best := capRule{ceiling: 100}
+	for _, r := range rules {
+		if r.ceiling < best.ceiling {
+			best = r
+		}
+	}
+
+	if result.Confidence > best.ceiling {
+		result.OriginalConfidence = result.Confidence
+		result.CalibrationReason = best.reason
+		result.Confidence = best.ceiling
+	}
+}
+
+// evaluateRules returns all cap rules that fire for the given signals.
+func evaluateRules(s CalibrationSignals) []capRule {
+	var rules []capRule
 
 	// Rule 1: Claims production bug but diff doesn't touch the blamed files.
-	// The LLM is correlating symptoms with unrelated code changes.
 	if s.BugLocationIsCode && !s.DiffIntersection {
-		if capUncertain < cap {
-			cap = capUncertain
-			reason = "production_bug_no_diff_intersection"
-		}
+		rules = append(rules, capRule{capUncertain, "production_bug_no_diff_intersection"})
 	}
 
-	// Rule 2: >50% of jobs failed with same pattern — almost certainly systemic,
-	// not a localized code regression.
+	// Rule 2: >50% of jobs failed — almost certainly systemic, not localized.
 	if s.BlastRadius > 0.5 && s.BugLocationIsCode {
-		if capUncertain < cap {
-			cap = capUncertain
-			reason = "high_blast_radius_code_blame"
-		}
+		rules = append(rules, capRule{capUncertain, "high_blast_radius_code_blame"})
 	}
 
-	// Rule 3: All RCAs are network errors blamed on code — strong infrastructure signal.
+	// Rule 3: All RCAs are network errors blamed on code.
 	if s.HasNetworkErrors && s.AllSameErrorType && s.BugLocationIsCode {
-		if capAmbiguous < cap {
-			cap = capAmbiguous
-			reason = "uniform_network_errors_code_blame"
-		}
+		rules = append(rules, capRule{capAmbiguous, "uniform_network_errors_code_blame"})
 	}
 
-	// Rule 5: LLM classified as code bug but its own evidence mentions HTTP/network
-	// errors — it's confusing a proximal UI crash with an underlying API failure.
-	// Exception: if the PR diff touches error handling / API code, the HTTP error
-	// may be a legitimate code bug (the PR broke the error handler).
+	// Rule 5: Evidence mentions HTTP/API errors but classified as code bug.
+	// Exception: skipped when PR diff touches error handling code.
 	if s.BugLocationIsCode && s.HasHiddenInfraEvidence && !s.HasNetworkErrors && !s.DiffTouchesErrorPaths {
-		if capAmbiguous < cap {
-			cap = capAmbiguous
-			reason = "evidence_contradicts_classification"
-		}
+		rules = append(rules, capRule{capAmbiguous, "evidence_contradicts_classification"})
 	}
 
-	// Rule 4: LLM itself is uncertain about bug location — can't be 80+ confident
-	// about the diagnosis if you don't know where the bug lives.
+	// Rule 4: LLM itself uncertain about bug location.
 	if s.BugLocConfLow {
-		if capAmbiguous < cap {
-			cap = capAmbiguous
-			reason = "low_bug_location_confidence"
-		}
+		rules = append(rules, capRule{capAmbiguous, "low_bug_location_confidence"})
 	}
 
-	if result.Confidence > cap {
-		result.OriginalConfidence = result.Confidence
-		result.CalibrationReason = reason
-		result.Confidence = cap
-	}
+	return rules
 }
 
 // computeSignals extracts deterministic calibration signals from the analysis
@@ -132,20 +131,42 @@ func computeSignals(ctx context.Context, result *llm.AnalysisResult,
 		DiffIntersection: true, // assume intersection unless proven otherwise
 	}
 
-	// Blast radius: fraction of jobs that failed
-	if len(jobs) > 0 {
-		failed := 0
-		for _, j := range jobs {
-			if j.Conclusion == ci.ConclusionFailure {
-				failed++
-			}
-		}
-		s.BlastRadius = float64(failed) / float64(len(jobs))
+	s.BlastRadius = computeBlastRadius(jobs)
+	extractRCASignals(&s, result.RCAs)
+
+	if s.BugLocationIsCode && !s.HasNetworkErrors {
+		s.HasHiddenInfraEvidence = anyRCAContainsInfraEvidence(result.RCAs)
 	}
 
-	// RCA-level signals
-	failureTypes := map[string]struct{}{}
-	for _, rca := range result.RCAs {
+	if diff != nil && run != nil && s.BugLocationIsCode {
+		files, err := diff.GetChangedFiles(ctx, ci.ChangeRef{HeadSHA: run.CommitSHA})
+		if err == nil && len(files) > 0 {
+			s.DiffIntersection = checkDiffIntersectionFromFiles(result, files)
+			s.DiffTouchesErrorPaths = checkErrorPaths(files)
+		}
+	}
+
+	return s
+}
+
+// computeBlastRadius returns the fraction of jobs that failed.
+func computeBlastRadius(jobs []ci.Job) float64 {
+	if len(jobs) == 0 {
+		return 0
+	}
+	failed := 0
+	for _, j := range jobs {
+		if j.Conclusion == ci.ConclusionFailure {
+			failed++
+		}
+	}
+	return float64(failed) / float64(len(jobs))
+}
+
+// extractRCASignals populates RCA-level flags from the analyses array.
+func extractRCASignals(s *CalibrationSignals, rcas []llm.RootCauseAnalysis) {
+	failureTypes := make(map[string]struct{}, len(rcas))
+	for _, rca := range rcas {
 		if rca.BugLocation == llm.BugLocationProduction {
 			s.BugLocationIsCode = true
 		}
@@ -159,29 +180,18 @@ func computeSignals(ctx context.Context, result *llm.AnalysisResult,
 			s.HasNetworkErrors = true
 		}
 	}
-	s.AllSameErrorType = len(failureTypes) == 1 && len(result.RCAs) > 0
+	s.AllSameErrorType = len(failureTypes) == 1 && len(rcas) > 0
+}
 
-	// Hidden infra evidence: LLM's own text mentions HTTP/network errors
-	// but failure_type is not "network" — cognitive dissonance.
-	if s.BugLocationIsCode && !s.HasNetworkErrors {
-		for _, rca := range result.RCAs {
-			if containsInfraEvidence(rca) {
-				s.HasHiddenInfraEvidence = true
-				break
-			}
+// anyRCAContainsInfraEvidence checks if any RCA's text mentions infrastructure
+// signals (HTTP errors, connection failures) that the LLM didn't classify.
+func anyRCAContainsInfraEvidence(rcas []llm.RootCauseAnalysis) bool {
+	for _, rca := range rcas {
+		if containsInfraEvidence(rca) {
+			return true
 		}
 	}
-
-	// Diff-fault intersection and error path detection
-	if diff != nil && run != nil && s.BugLocationIsCode {
-		files, err := diff.GetChangedFiles(ctx, ci.ChangeRef{HeadSHA: run.CommitSHA})
-		if err == nil && len(files) > 0 {
-			s.DiffIntersection = checkDiffIntersectionFromFiles(result, files)
-			s.DiffTouchesErrorPaths = checkErrorPaths(files)
-		}
-	}
-
-	return s
+	return false
 }
 
 // errorPathRe matches file paths likely related to error handling or API client code.

--- a/pkg/analysis/calibrate.go
+++ b/pkg/analysis/calibrate.go
@@ -1,0 +1,238 @@
+package analysis
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/kamilpajak/heisenberg/pkg/ci"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+)
+
+// infraEvidenceRe matches HTTP error codes, connection errors, and API failure
+// patterns in free text. Used to detect infrastructure signals the LLM saw
+// but didn't factor into its classification.
+var infraEvidenceRe = regexp.MustCompile(`(?i)(` +
+	`HTTP\s*[45]\d\d|` + // HTTP 400, HTTP 503, etc.
+	`\b[45]\d\d\s+(Bad Request|Unauthorized|Forbidden|Not Found|Internal Server Error|Bad Gateway|Service Unavailable)|` +
+	`ECONNREFUSED|ERR_CONNECTION|connection refused|` +
+	`API\s+(error|failure|failed)|` +
+	`service\s+unavailable|gateway\s+timeout` +
+	`)`)
+
+// diffProvider abstracts the ability to fetch changed files for a PR/commit.
+// Satisfied by ci.Provider but allows testing with mocks.
+type diffProvider interface {
+	GetChangedFiles(ctx context.Context, ref ci.ChangeRef) ([]ci.ChangedFile, error)
+}
+
+// CalibrationSignals contains deterministic signals for confidence adjustment.
+// Exported with JSON tags to enable logging as training data for future
+// data-driven calibration (#50).
+type CalibrationSignals struct {
+	BlastRadius            float64 `json:"blast_radius"`
+	DiffIntersection       bool    `json:"diff_intersection"`
+	AllSameErrorType       bool    `json:"all_same_error_type"`
+	HasNetworkErrors       bool    `json:"has_network_errors"`
+	BugLocationIsCode      bool    `json:"bug_location_is_code"`
+	BugLocConfLow          bool    `json:"bug_loc_conf_low"`
+	HasHiddenInfraEvidence bool    `json:"has_hidden_infra_evidence"`
+	DiffTouchesErrorPaths  bool    `json:"diff_touches_error_paths"`
+}
+
+// calibrateResult adjusts confidence based on heuristic signals that the LLM
+// cannot self-assess: diff-fault intersection, blast radius, and internal
+// consistency of the diagnosis.
+func calibrateResult(ctx context.Context, result *llm.AnalysisResult,
+	provider diffProvider, jobs []ci.Job, run *ci.Run) {
+
+	if result == nil || result.Category != llm.CategoryDiagnosis {
+		return
+	}
+
+	signals := computeSignals(ctx, result, provider, jobs, run)
+	applyConfidenceCaps(result, signals)
+}
+
+// Confidence cap thresholds aligned with the LLM rubric:
+//
+//	80-100: clear root cause with strong evidence
+//	40-79:  likely cause but some ambiguity
+//	0-39:   uncertain
+const (
+	capUncertain = 39 // "uncertain" tier
+	capAmbiguous = 49 // low end of "likely" tier
+)
+
+// applyConfidenceCaps enforces hard confidence ceilings when the LLM's
+// structured output contradicts deterministic pipeline signals.
+func applyConfidenceCaps(result *llm.AnalysisResult, s CalibrationSignals) {
+	cap := 100
+	reason := ""
+
+	// Rule 1: Claims production bug but diff doesn't touch the blamed files.
+	// The LLM is correlating symptoms with unrelated code changes.
+	if s.BugLocationIsCode && !s.DiffIntersection {
+		if capUncertain < cap {
+			cap = capUncertain
+			reason = "production_bug_no_diff_intersection"
+		}
+	}
+
+	// Rule 2: >50% of jobs failed with same pattern — almost certainly systemic,
+	// not a localized code regression.
+	if s.BlastRadius > 0.5 && s.BugLocationIsCode {
+		if capUncertain < cap {
+			cap = capUncertain
+			reason = "high_blast_radius_code_blame"
+		}
+	}
+
+	// Rule 3: All RCAs are network errors blamed on code — strong infrastructure signal.
+	if s.HasNetworkErrors && s.AllSameErrorType && s.BugLocationIsCode {
+		if capAmbiguous < cap {
+			cap = capAmbiguous
+			reason = "uniform_network_errors_code_blame"
+		}
+	}
+
+	// Rule 5: LLM classified as code bug but its own evidence mentions HTTP/network
+	// errors — it's confusing a proximal UI crash with an underlying API failure.
+	// Exception: if the PR diff touches error handling / API code, the HTTP error
+	// may be a legitimate code bug (the PR broke the error handler).
+	if s.BugLocationIsCode && s.HasHiddenInfraEvidence && !s.HasNetworkErrors && !s.DiffTouchesErrorPaths {
+		if capAmbiguous < cap {
+			cap = capAmbiguous
+			reason = "evidence_contradicts_classification"
+		}
+	}
+
+	// Rule 4: LLM itself is uncertain about bug location — can't be 80+ confident
+	// about the diagnosis if you don't know where the bug lives.
+	if s.BugLocConfLow {
+		if capAmbiguous < cap {
+			cap = capAmbiguous
+			reason = "low_bug_location_confidence"
+		}
+	}
+
+	if result.Confidence > cap {
+		result.OriginalConfidence = result.Confidence
+		result.CalibrationReason = reason
+		result.Confidence = cap
+	}
+}
+
+// computeSignals extracts deterministic calibration signals from the analysis
+// result, PR diff, and job data.
+func computeSignals(ctx context.Context, result *llm.AnalysisResult,
+	diff diffProvider, jobs []ci.Job, run *ci.Run) CalibrationSignals {
+
+	s := CalibrationSignals{
+		DiffIntersection: true, // assume intersection unless proven otherwise
+	}
+
+	// Blast radius: fraction of jobs that failed
+	if len(jobs) > 0 {
+		failed := 0
+		for _, j := range jobs {
+			if j.Conclusion == ci.ConclusionFailure {
+				failed++
+			}
+		}
+		s.BlastRadius = float64(failed) / float64(len(jobs))
+	}
+
+	// RCA-level signals
+	failureTypes := map[string]struct{}{}
+	for _, rca := range result.RCAs {
+		if rca.BugLocation == llm.BugLocationProduction {
+			s.BugLocationIsCode = true
+		}
+		if strings.EqualFold(rca.BugLocationConfidence, "low") {
+			s.BugLocConfLow = true
+		}
+		if rca.FailureType != "" {
+			failureTypes[rca.FailureType] = struct{}{}
+		}
+		if rca.FailureType == llm.FailureTypeNetwork {
+			s.HasNetworkErrors = true
+		}
+	}
+	s.AllSameErrorType = len(failureTypes) == 1 && len(result.RCAs) > 0
+
+	// Hidden infra evidence: LLM's own text mentions HTTP/network errors
+	// but failure_type is not "network" — cognitive dissonance.
+	if s.BugLocationIsCode && !s.HasNetworkErrors {
+		for _, rca := range result.RCAs {
+			if containsInfraEvidence(rca) {
+				s.HasHiddenInfraEvidence = true
+				break
+			}
+		}
+	}
+
+	// Diff-fault intersection and error path detection
+	if diff != nil && run != nil && s.BugLocationIsCode {
+		files, err := diff.GetChangedFiles(ctx, ci.ChangeRef{HeadSHA: run.CommitSHA})
+		if err == nil && len(files) > 0 {
+			s.DiffIntersection = checkDiffIntersectionFromFiles(result, files)
+			s.DiffTouchesErrorPaths = checkErrorPaths(files)
+		}
+	}
+
+	return s
+}
+
+// errorPathRe matches file paths likely related to error handling or API client code.
+var errorPathRe = regexp.MustCompile(`(?i)(error[_-]?handler|api[_-]?client|http[_-]?client|interceptor|middleware|error[_-]?boundary|exception|retry|fallback)`)
+
+// containsInfraEvidence checks if an RCA's text mentions HTTP errors or
+// connection failures that suggest an infrastructure issue the LLM didn't
+// classify as such.
+func containsInfraEvidence(rca llm.RootCauseAnalysis) bool {
+	if infraEvidenceRe.MatchString(rca.Symptom) || infraEvidenceRe.MatchString(rca.RootCause) {
+		return true
+	}
+	for _, ev := range rca.Evidence {
+		if infraEvidenceRe.MatchString(ev.Content) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkDiffIntersectionFromFiles checks if any RCA file paths appear in the
+// changed files list.
+func checkDiffIntersectionFromFiles(result *llm.AnalysisResult, files []ci.ChangedFile) bool {
+	diffPaths := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		diffPaths[f.Path] = struct{}{}
+	}
+
+	for _, rca := range result.RCAs {
+		if rca.Location != nil && rca.Location.FilePath != "" {
+			if _, ok := diffPaths[rca.Location.FilePath]; ok {
+				return true
+			}
+		}
+		if rca.BugCodeLocation != nil && rca.BugCodeLocation.FilePath != "" {
+			if _, ok := diffPaths[rca.BugCodeLocation.FilePath]; ok {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// checkErrorPaths returns true if any changed file matches common error
+// handling or API client patterns.
+func checkErrorPaths(files []ci.ChangedFile) bool {
+	for _, f := range files {
+		if errorPathRe.MatchString(f.Path) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/analysis/calibrate_test.go
+++ b/pkg/analysis/calibrate_test.go
@@ -1,0 +1,404 @@
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kamilpajak/heisenberg/pkg/ci"
+	"github.com/kamilpajak/heisenberg/pkg/llm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyConfidenceCaps_ProductionBugNoDiffIntersection(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 95, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode: true,
+		DiffIntersection:  false,
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 39, result.Confidence, "should cap at 39 when production bug has no diff overlap")
+	assert.Equal(t, 95, result.OriginalConfidence)
+	assert.Contains(t, result.CalibrationReason, "no_diff_intersection")
+}
+
+func TestApplyConfidenceCaps_HighBlastRadiusCodeBlame(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 90, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BlastRadius:       0.8,
+		BugLocationIsCode: true,
+		DiffIntersection:  true, // even with intersection, blast radius overrides
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 39, result.Confidence, "should cap at 39 when >50% jobs fail and code blamed")
+	assert.Equal(t, 90, result.OriginalConfidence)
+}
+
+func TestApplyConfidenceCaps_NetworkErrorsCodeBlame(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 85, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		HasNetworkErrors:  true,
+		AllSameErrorType:  true,
+		BugLocationIsCode: true,
+		DiffIntersection:  true,
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 49, result.Confidence, "should cap at 49 for uniform network errors blamed on code")
+	assert.Equal(t, 85, result.OriginalConfidence)
+}
+
+func TestApplyConfidenceCaps_LowBugLocationConfidence(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 80, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocConfLow:    true,
+		DiffIntersection: true,
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 49, result.Confidence, "should cap at 49 when LLM is uncertain about bug location")
+}
+
+func TestApplyConfidenceCaps_NoCapNeeded(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 90, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode: true,
+		DiffIntersection:  true, // diff overlaps — legitimate
+		BlastRadius:       0.1,  // low blast radius
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 90, result.Confidence, "should not cap when signals are clean")
+	assert.Equal(t, 0, result.OriginalConfidence, "should not set original when no cap")
+}
+
+func TestApplyConfidenceCaps_AlreadyBelowCap(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 30, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode: true,
+		DiffIntersection:  false,
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 30, result.Confidence, "should not change confidence already below cap")
+	assert.Equal(t, 0, result.OriginalConfidence, "should not set original when no cap applied")
+}
+
+func TestApplyConfidenceCaps_MultipleRulesPicksLowest(t *testing.T) {
+	result := &llm.AnalysisResult{Confidence: 95, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode: true,
+		DiffIntersection:  false, // → cap 39
+		BlastRadius:       0.8,   // → cap 39
+		HasNetworkErrors:  true,  // → cap 49
+		AllSameErrorType:  true,
+		BugLocConfLow:     true, // → cap 49
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 39, result.Confidence, "should apply lowest cap from all rules")
+}
+
+// --- computeSignals tests ---
+
+type mockDiffProvider struct {
+	files []ci.ChangedFile
+	err   error
+}
+
+func (m *mockDiffProvider) GetChangedFiles(_ context.Context, _ ci.ChangeRef) ([]ci.ChangedFile, error) {
+	return m.files, m.err
+}
+
+func TestComputeSignals_BlastRadius(t *testing.T) {
+	jobs := []ci.Job{
+		{Conclusion: ci.ConclusionFailure},
+		{Conclusion: ci.ConclusionFailure},
+		{Conclusion: ci.ConclusionSuccess},
+		{Conclusion: ci.ConclusionSuccess},
+	}
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{FailureType: "assertion", BugLocation: llm.BugLocationProduction},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, jobs, &ci.Run{})
+	assert.InDelta(t, 0.5, signals.BlastRadius, 0.01, "2 of 4 jobs failed = 50%")
+}
+
+func TestComputeSignals_DiffIntersection(t *testing.T) {
+	diff := &mockDiffProvider{
+		files: []ci.ChangedFile{
+			{Path: "src/pricing.ts"},
+			{Path: "tests/pricing.test.ts"},
+		},
+	}
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				BugLocation:     llm.BugLocationProduction,
+				BugCodeLocation: &llm.CodeLocation{FilePath: "src/pricing.ts"},
+			},
+		},
+	}
+	run := &ci.Run{CommitSHA: "abc123"}
+
+	signals := computeSignals(context.Background(), result, diff, nil, run)
+	assert.True(t, signals.DiffIntersection, "bug_code_file_path matches diff file")
+}
+
+func TestComputeSignals_NoDiffIntersection(t *testing.T) {
+	diff := &mockDiffProvider{
+		files: []ci.ChangedFile{
+			{Path: "src/checkout.ts"},
+		},
+	}
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				BugLocation:     llm.BugLocationProduction,
+				BugCodeLocation: &llm.CodeLocation{FilePath: "src/pricing.ts"},
+			},
+		},
+	}
+	run := &ci.Run{CommitSHA: "abc123"}
+
+	signals := computeSignals(context.Background(), result, diff, nil, run)
+	assert.False(t, signals.DiffIntersection, "bug_code_file_path does NOT match any diff file")
+}
+
+func TestComputeSignals_DiffIntersectionViaTestLocation(t *testing.T) {
+	diff := &mockDiffProvider{
+		files: []ci.ChangedFile{
+			{Path: "tests/checkout.spec.ts"},
+		},
+	}
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				Location:    &llm.CodeLocation{FilePath: "tests/checkout.spec.ts"},
+				BugLocation: llm.BugLocationProduction,
+			},
+		},
+	}
+	run := &ci.Run{CommitSHA: "abc123"}
+
+	signals := computeSignals(context.Background(), result, diff, nil, run)
+	assert.True(t, signals.DiffIntersection, "test location matches diff file")
+}
+
+func TestComputeSignals_NoDiffProvider(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{BugLocation: llm.BugLocationProduction},
+		},
+	}
+
+	// nil provider = can't check diff, assume intersection (don't penalize)
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.DiffIntersection, "nil provider should assume intersection")
+}
+
+func TestComputeSignals_AllSameErrorType(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{FailureType: "network"},
+			{FailureType: "network"},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.AllSameErrorType)
+	assert.True(t, signals.HasNetworkErrors)
+}
+
+func TestComputeSignals_MixedErrorTypes(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{FailureType: "network"},
+			{FailureType: "assertion"},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.False(t, signals.AllSameErrorType)
+	assert.True(t, signals.HasNetworkErrors)
+}
+
+func TestComputeSignals_BugLocationFlags(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				BugLocation:           llm.BugLocationProduction,
+				BugLocationConfidence: "low",
+			},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.BugLocationIsCode)
+	assert.True(t, signals.BugLocConfLow)
+}
+
+func TestApplyConfidenceCaps_EvidenceContradicts(t *testing.T) {
+	// LLM classified as assertion/production but evidence mentions HTTP errors
+	result := &llm.AnalysisResult{Confidence: 95, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode:      true,
+		DiffIntersection:       true,  // diff overlaps — looks legit
+		HasHiddenInfraEvidence: true,  // but evidence mentions HTTP 400!
+		HasNetworkErrors:       false, // failure_type is assertion, not network
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 49, result.Confidence, "should cap when evidence contradicts classification")
+	assert.Equal(t, "evidence_contradicts_classification", result.CalibrationReason)
+}
+
+func TestComputeSignals_HiddenInfraInSymptom(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				FailureType: "assertion",
+				BugLocation: llm.BugLocationProduction,
+				Symptom:     "Tests fail with NoSuchElementException. Browser console shows HTTP 400 Bad Request.",
+				RootCause:   "TypeError in component rendering",
+			},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.HasHiddenInfraEvidence, "HTTP 400 in symptom should be detected")
+}
+
+func TestComputeSignals_HiddenInfraInEvidence(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				FailureType: "assertion",
+				BugLocation: llm.BugLocationProduction,
+				RootCause:   "TypeError in component",
+				Evidence: []llm.Evidence{
+					{Type: "log", Content: "Browser console: GET /api/search returned 503 Service Unavailable"},
+				},
+			},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.HasHiddenInfraEvidence, "HTTP 503 in evidence should be detected")
+}
+
+func TestComputeSignals_HiddenInfraConnectionRefused(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				FailureType: "assertion",
+				BugLocation: llm.BugLocationProduction,
+				Symptom:     "UI does not load, ECONNREFUSED on port 3000",
+			},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.HasHiddenInfraEvidence)
+}
+
+func TestComputeSignals_HiddenInfraAPIFailure(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				FailureType: "assertion",
+				BugLocation: llm.BugLocationProduction,
+				Symptom:     "Welcome page does not load",
+				RootCause:   "API failure causes frontend to crash on undefined data",
+			},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.True(t, signals.HasHiddenInfraEvidence, "'API failure' in root cause should trigger")
+}
+
+func TestApplyConfidenceCaps_EvidenceContradicts_ButDiffTouchesErrorHandling(t *testing.T) {
+	// LLM evidence mentions HTTP 500 but PR actually changed error handling code.
+	// This is a legitimate code bug — Rule 5 should NOT fire.
+	result := &llm.AnalysisResult{Confidence: 95, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode:      true,
+		DiffIntersection:       true,
+		HasHiddenInfraEvidence: true,
+		HasNetworkErrors:       false,
+		DiffTouchesErrorPaths:  true, // PR changed API/error handling code
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 95, result.Confidence, "should not cap when diff touches error handling code")
+}
+
+func TestComputeSignals_DiffTouchesErrorPaths(t *testing.T) {
+	diff := &mockDiffProvider{
+		files: []ci.ChangedFile{
+			{Path: "src/api/error-handler.ts"},
+			{Path: "src/components/view.ts"},
+		},
+	}
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{BugLocation: llm.BugLocationProduction},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, diff, nil, &ci.Run{CommitSHA: "abc"})
+	assert.True(t, signals.DiffTouchesErrorPaths, "error-handler.ts should trigger")
+}
+
+func TestComputeSignals_DiffNoErrorPaths(t *testing.T) {
+	diff := &mockDiffProvider{
+		files: []ci.ChangedFile{
+			{Path: "src/components/header.tsx"},
+			{Path: "src/styles/main.css"},
+		},
+	}
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{BugLocation: llm.BugLocationProduction},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, diff, nil, &ci.Run{CommitSHA: "abc"})
+	assert.False(t, signals.DiffTouchesErrorPaths)
+}
+
+func TestComputeSignals_NoHiddenInfra(t *testing.T) {
+	result := &llm.AnalysisResult{
+		RCAs: []llm.RootCauseAnalysis{
+			{
+				FailureType: "assertion",
+				BugLocation: llm.BugLocationProduction,
+				Symptom:     "expect(price).toBe('$10.00') received '$0.00'",
+				RootCause:   "Pricing logic returns zero for valid inputs",
+			},
+		},
+	}
+
+	signals := computeSignals(context.Background(), result, nil, nil, &ci.Run{})
+	assert.False(t, signals.HasHiddenInfraEvidence, "pure assertion without HTTP errors")
+}
+
+func TestApplyConfidenceCaps_InfrastructureBugLocationNotCapped(t *testing.T) {
+	// When LLM correctly identifies infrastructure — no cap should apply
+	result := &llm.AnalysisResult{Confidence: 95, Category: llm.CategoryDiagnosis}
+	signals := CalibrationSignals{
+		BugLocationIsCode: false, // LLM said "infrastructure" — correct
+		BlastRadius:       0.8,
+		HasNetworkErrors:  true,
+		AllSameErrorType:  true,
+		DiffIntersection:  false,
+	}
+
+	applyConfidenceCaps(result, signals)
+	assert.Equal(t, 95, result.Confidence, "should not cap when LLM correctly identified infra")
+}

--- a/pkg/analysis/calibrate_test.go
+++ b/pkg/analysis/calibrate_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testPricingFile = "src/pricing.ts"
+
 func TestApplyConfidenceCaps_ProductionBugNoDiffIntersection(t *testing.T) {
 	result := &llm.AnalysisResult{Confidence: 95, Category: llm.CategoryDiagnosis}
 	signals := CalibrationSignals{
@@ -131,7 +133,7 @@ func TestComputeSignals_BlastRadius(t *testing.T) {
 func TestComputeSignals_DiffIntersection(t *testing.T) {
 	diff := &mockDiffProvider{
 		files: []ci.ChangedFile{
-			{Path: "src/pricing.ts"},
+			{Path: testPricingFile},
 			{Path: "tests/pricing.test.ts"},
 		},
 	}
@@ -139,7 +141,7 @@ func TestComputeSignals_DiffIntersection(t *testing.T) {
 		RCAs: []llm.RootCauseAnalysis{
 			{
 				BugLocation:     llm.BugLocationProduction,
-				BugCodeLocation: &llm.CodeLocation{FilePath: "src/pricing.ts"},
+				BugCodeLocation: &llm.CodeLocation{FilePath: testPricingFile},
 			},
 		},
 	}
@@ -159,7 +161,7 @@ func TestComputeSignals_NoDiffIntersection(t *testing.T) {
 		RCAs: []llm.RootCauseAnalysis{
 			{
 				BugLocation:     llm.BugLocationProduction,
-				BugCodeLocation: &llm.CodeLocation{FilePath: "src/pricing.ts"},
+				BugCodeLocation: &llm.CodeLocation{FilePath: testPricingFile},
 			},
 		},
 	}

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -98,6 +98,7 @@ func Run(ctx context.Context, p Params) (*llm.AnalysisResult, error) {
 	}
 
 	stampRunMeta(result, p, ciRun)
+	calibrateResult(ctx, result, p.CI, jobs, ciRun)
 	matchPatterns(ctx, p.PatternMatcher, result)
 	return result, err
 }
@@ -177,7 +178,7 @@ func runClustered(ctx context.Context, p Params,
 		emitInfo(p.Emitter, fmt.Sprintf("[Cluster %d/%d] Analyzing %d jobs (%s)...",
 			i+1, len(cr.Clusters), len(c.Failures), truncate(c.Signature.RawExcerpt, 60)))
 
-		clusterCtx := buildClusterContext(ciRun, c, i+1, len(cr.Clusters), allJobs, artifacts)
+		clusterCtx := buildClusterContext(ciRun, c, i+1, len(cr.Clusters), cr.TotalFailed, allJobs, artifacts)
 
 		handler := &ToolHandler{
 			CI:           p.CI,
@@ -202,7 +203,7 @@ func runClustered(ctx context.Context, p Params,
 		emitInfo(p.Emitter, fmt.Sprintf("[Other] Analyzing %d unclustered jobs...", len(cr.Unclustered)))
 
 		uc := buildUnclusteredCluster(cr.Unclustered, len(cr.Clusters)+1)
-		clusterCtx := buildClusterContext(ciRun, uc, uc.ID, len(cr.Clusters)+1, allJobs, artifacts)
+		clusterCtx := buildClusterContext(ciRun, uc, uc.ID, len(cr.Clusters)+1, cr.TotalFailed, allJobs, artifacts)
 		ucHandler := &ToolHandler{
 			CI:    p.CI,
 			RunID: p.RunID, PRNumber: prNumber, HeadSHA: ciRun.CommitSHA,
@@ -283,7 +284,7 @@ func filterFailed(jobs []ci.Job) []ci.Job {
 
 // buildClusterContext creates a focused initial context for one cluster.
 func buildClusterContext(run *ci.Run, c cluster.Cluster,
-	clusterNum, totalClusters int, allJobs []ci.Job, artifacts []ci.Artifact) string {
+	clusterNum, totalClusters, totalFailed int, allJobs []ci.Job, artifacts []ci.Artifact) string {
 
 	var b strings.Builder
 
@@ -299,6 +300,15 @@ func buildClusterContext(run *ci.Run, c cluster.Cluster,
 	b.WriteString("\nYou are analyzing a specific cluster of related failures. ")
 	b.WriteString("Do not assume these are the only failures in this run. ")
 	b.WriteString("Focus on the root cause shared by this cluster.\n")
+
+	if totalFailed > 0 {
+		blastPct := float64(len(c.Failures)) / float64(totalFailed) * 100
+		if blastPct > 25 {
+			fmt.Fprintf(&b, "\nSYSTEM NOTE: %.0f%% of all failed jobs (%d of %d) share this "+
+				"exact error pattern. This strongly indicates a systemic infrastructure or "+
+				"environment issue rather than a localized code regression.\n", blastPct, len(c.Failures), totalFailed)
+		}
+	}
 
 	b.WriteString("\n### Affected Jobs\n")
 	for _, f := range c.Failures {

--- a/pkg/analysis/run_test.go
+++ b/pkg/analysis/run_test.go
@@ -203,7 +203,7 @@ func TestBuildClusterContext(t *testing.T) {
 	}
 	artifacts := []ci.Artifact{{Name: htmlReportName, SizeBytes: 5000}}
 
-	ctx := buildClusterContext(run, c, 1, 3, nil, artifacts)
+	ctx := buildClusterContext(run, c, 1, 3, 0, nil, artifacts)
 
 	assert.Contains(t, ctx, "Run ID: 12345")
 	assert.Contains(t, ctx, "Cluster 1 of 3")
@@ -217,6 +217,35 @@ func TestBuildClusterContext(t *testing.T) {
 	assert.Contains(t, ctx, "shared root cause")
 }
 
+func TestBuildClusterContext_BlastRadiusWarning(t *testing.T) {
+	run := &ci.Run{ID: 1, Conclusion: "failure"}
+	c := cluster.Cluster{
+		Failures: []cluster.FailureInfo{
+			{JobID: 1, JobName: "Test 1"},
+			{JobID: 2, JobName: "Test 2"},
+			{JobID: 3, JobName: "Test 3"},
+		},
+		Representative: cluster.FailureInfo{JobName: "Test 1", LogTail: "error"},
+	}
+
+	// 3 of 4 total failed jobs (75%) in this cluster → blast radius warning
+	ctx := buildClusterContext(run, c, 1, 1, 4, nil, nil)
+	assert.Contains(t, ctx, "SYSTEM NOTE")
+	assert.Contains(t, ctx, "75%")
+}
+
+func TestBuildClusterContext_NoBlastRadiusWarning(t *testing.T) {
+	run := &ci.Run{ID: 1, Conclusion: "failure"}
+	c := cluster.Cluster{
+		Failures:       []cluster.FailureInfo{{JobID: 1, JobName: "Test"}},
+		Representative: cluster.FailureInfo{JobName: "Test", LogTail: "error"},
+	}
+
+	// 1 of 10 total failed jobs (10%) — no warning
+	ctx := buildClusterContext(run, c, 1, 5, 10, nil, nil)
+	assert.NotContains(t, ctx, "SYSTEM NOTE")
+}
+
 func TestBuildClusterContext_NoArtifacts(t *testing.T) {
 	run := &ci.Run{ID: 1, Conclusion: "failure"}
 	c := cluster.Cluster{
@@ -224,7 +253,7 @@ func TestBuildClusterContext_NoArtifacts(t *testing.T) {
 		Representative: cluster.FailureInfo{JobName: "Test", LogTail: "error"},
 	}
 
-	ctx := buildClusterContext(run, c, 1, 1, nil, nil)
+	ctx := buildClusterContext(run, c, 1, 1, 0, nil, nil)
 
 	assert.Contains(t, ctx, "Cluster 1 of 1")
 	assert.NotContains(t, ctx, testReportLabel)
@@ -303,7 +332,7 @@ func TestBuildClusterContext_ExpiredArtifactsSkipped(t *testing.T) {
 		{Name: "blob-report", SizeBytes: 3000, Expired: false},
 	}
 
-	ctx := buildClusterContext(run, c, 1, 1, nil, artifacts)
+	ctx := buildClusterContext(run, c, 1, 1, 0, nil, artifacts)
 
 	assert.NotContains(t, ctx, htmlReportName, "expired artifacts should be skipped")
 	assert.Contains(t, ctx, "blob-report")

--- a/pkg/llm/client.go
+++ b/pkg/llm/client.go
@@ -244,6 +244,20 @@ Confidence scoring (0-100):
   - 40-79: Likely cause identified but some ambiguity remains
   - 0-39: Uncertain, multiple possible causes or insufficient evidence
 
+  IMPORTANT: Before finalizing your diagnosis, consider whether the root cause
+  could be EXTERNAL to this repository:
+  - External service outage or configuration change
+  - Environment/infrastructure issue not visible in logs
+  - Upstream API contract change managed by a different team
+
+  If many failed tests share the same error pattern (e.g., same HTTP status code,
+  same TypeError), this strongly suggests a systemic issue rather than a code
+  regression. In that case, prefer bug_location="infrastructure" and lower your
+  confidence unless you have direct evidence linking the PR diff to the error.
+
+  Do NOT assume the PR diff caused the failure just because code changed and
+  tests failed at the same time. Correlation is not causation.
+
 Missing information sensitivity:
   - high: Backend logs, Docker state, or CI environment data would likely reveal the root cause
   - medium: Additional data might help but current evidence is reasonable

--- a/pkg/llm/client_test.go
+++ b/pkg/llm/client_test.go
@@ -268,6 +268,22 @@ func TestIsRetryable(t *testing.T) {
 	}
 }
 
+func TestSystemPrompt_ContainsExternalCauseGuidance(t *testing.T) {
+	prompt := systemPrompt("")
+	text := prompt.Parts[0].Text
+
+	assert.Contains(t, text, "EXTERNAL", "should mention external root causes")
+	assert.Contains(t, text, "Correlation is not causation", "should warn about false correlations")
+	assert.Contains(t, text, "infrastructure", "should mention infrastructure as alternative")
+}
+
+func TestSystemPrompt_IncludesProviderHints(t *testing.T) {
+	prompt := systemPrompt("Use get_test_results for Azure")
+	text := prompt.Parts[0].Text
+
+	assert.Contains(t, text, "Use get_test_results for Azure")
+}
+
 // gemini429Body is a real Gemini API 429 response captured from production.
 const gemini429Body = `{"error":{"code":429,"message":"You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit.\n\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_requests_per_model_per_day, limit: 250, model: gemini-3.1-pro\n\nPlease retry in 4h59m27.724879759s.","status":"RESOURCE_EXHAUSTED"}}`
 

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -112,18 +112,20 @@ const SchemaV1 = "1"
 
 // AnalysisResult holds the final output from the agent loop.
 type AnalysisResult struct {
-	Text        string              `json:"text"`
-	Category    string              `json:"category"`             // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
-	Confidence  int                 `json:"confidence"`           // 0-100, meaningful only for "diagnosis"
-	Sensitivity string              `json:"sensitivity"`          // "high", "medium", "low", meaningful only for "diagnosis"
-	RCAs        []RootCauseAnalysis `json:"analyses,omitempty"`   // Structured diagnoses, one per failing test
-	RunID       int64               `json:"run_id,omitempty"`     // GitHub workflow run ID
-	Owner       string              `json:"owner,omitempty"`      // Repository owner
-	Repo        string              `json:"repo,omitempty"`       // Repository name
-	Branch      string              `json:"branch,omitempty"`     // Git branch name
-	CommitSHA   string              `json:"commit_sha,omitempty"` // Git commit SHA
-	Event       string              `json:"event,omitempty"`      // GitHub event type (push, pull_request)
-	Eval        *EvalMeta           `json:"eval,omitempty"`       // Performance metadata for eval
+	Text               string              `json:"text"`
+	Category           string              `json:"category"`                      // "diagnosis", "no_failures", "not_supported", or "" (model skipped done)
+	Confidence         int                 `json:"confidence"`                    // 0-100, meaningful only for "diagnosis"
+	Sensitivity        string              `json:"sensitivity"`                   // "high", "medium", "low", meaningful only for "diagnosis"
+	RCAs               []RootCauseAnalysis `json:"analyses,omitempty"`            // Structured diagnoses, one per failing test
+	RunID              int64               `json:"run_id,omitempty"`              // GitHub workflow run ID
+	Owner              string              `json:"owner,omitempty"`               // Repository owner
+	Repo               string              `json:"repo,omitempty"`                // Repository name
+	Branch             string              `json:"branch,omitempty"`              // Git branch name
+	CommitSHA          string              `json:"commit_sha,omitempty"`          // Git commit SHA
+	Event              string              `json:"event,omitempty"`               // GitHub event type (push, pull_request)
+	Eval               *EvalMeta           `json:"eval,omitempty"`                // Performance metadata for eval
+	OriginalConfidence int                 `json:"original_confidence,omitempty"` // Pre-calibration confidence (0 = not adjusted)
+	CalibrationReason  string              `json:"calibration_reason,omitempty"`  // Why confidence was capped
 }
 
 // EvalMeta captures performance metrics from the agent loop for evaluation.


### PR DESCRIPTION
Closes #49

## Summary

Add a post-LLM confidence calibration pipeline that applies hard caps when the LLM's structured diagnosis contradicts deterministic pipeline signals. Addresses the "closed-world assumption" problem where the LLM confidently blames code changes for failures caused by external factors invisible to it.

### Calibration rules
| Rule | Condition | Cap | Rationale |
|------|-----------|-----|-----------|
| 1 | Production bug claimed, blamed file not in PR diff | 39 | No evidence linking diff to failure |
| 2 | >50% blast radius + code blame | 39 | Systemic, not localized regression |
| 3 | Uniform network errors blamed on code | 49 | Infrastructure signal |
| 4 | LLM uncertain about bug location | 49 | Can't be 80+ confident without knowing where |
| 5 | Evidence text mentions HTTP/API errors but classified as code | 49 | Cognitive dissonance between evidence and classification |

Rule 5 has a **guardrail**: skipped when PR diff touches error handling/API client code (prevents penalizing legitimate code bugs that cause HTTP errors).

### Pre-LLM improvements
- System prompt now requires considering external root causes before finalizing
- "Correlation is not causation" guidance added
- Blast radius warning injected into cluster context when >25% of jobs share same error

### Architecture (V2-ready)
- `computeSignals()` extracts deterministic feature vector (blast radius, diff intersection, etc.)
- `applyConfidenceCaps()` applies rule-based caps (replaceable with trained model in #50)
- `CalibrationSignals` exported with JSON tags for future training data logging
- `OriginalConfidence` + `CalibrationReason` metadata in output for observability

### Research basis
- Perplexity Deep Research: industry approaches (Datadog, Trunk, Launchable, Google TAP)
- zen expert review: architectural design (hard caps > multipliers, Option C belt-and-suspenders)
- Community input on #49: isotonic regression (deferred to #50 — needs 500+ samples)

## Live test results
| Build | Real cause | Confidence | Calibrated? | Correct? |
|-------|-----------|------------|-------------|----------|
| Azure 176427 | External config | 95→**49** | Rule 5 | Correct — downranked |
| Azure 174629 | Chrome version | **95** | No | Correct — untouched |
| Next.js | Jest config | **100** | No | Correct — untouched |

## Test plan
- [x] 25 unit tests covering all rules, edge cases, false positive protection
- [x] `TestApplyConfidenceCaps_*` — 8 tests for cap logic
- [x] `TestComputeSignals_*` — 12 tests for signal extraction
- [x] `TestBuildClusterContext_BlastRadius*` — 2 tests for context injection
- [x] `TestSystemPrompt_*` — 2 tests for prompt changes
- [x] Live-validated on real Azure DevOps builds
- [x] All existing tests pass