### PR TITLE
feat(logclean): weighted log preprocessing behind HEISENBERG_LOG_WEIGHTED flag

### DIFF
--- a/pkg/logclean/logclean.go
+++ b/pkg/logclean/logclean.go
@@ -1,8 +1,15 @@
 package logclean
 
 import (
+	"os"
 	"regexp"
+	"sort"
 	"strings"
+)
+
+const (
+	weightedFlagEnv    = "HEISENBERG_LOG_WEIGHTED"
+	adjacencyBoostSize = 3
 )
 
 // GitHub Actions timestamp prefix: 2024-01-15T10:30:00.1234567Z
@@ -72,13 +79,101 @@ func Extract(logText string, maxBytes int) (string, Stats) {
 
 	stats.OutputLines = len(signalLines)
 
-	// Budget enforcement: if signal exceeds maxBytes, take the tail
+	// Budget enforcement: if signal exceeds maxBytes, select by weight (if enabled)
+	// or take the tail.
 	if len(result) > maxBytes {
-		result = result[len(result)-maxBytes:]
+		if weightedEnabled() {
+			result, stats.OutputLines = selectByWeight(lines, stripped, cleanupStart, maxBytes)
+			stats.DroppedLines = stats.InputLines - stats.OutputLines
+		} else {
+			result = result[len(result)-maxBytes:]
+		}
 	}
 
 	return result, stats
 }
+
+func weightedEnabled() bool {
+	return os.Getenv(weightedFlagEnv) == "1"
+}
+
+// selectByWeight picks the highest-weight lines that fit in maxBytes, preserving
+// chronological order. Returns the joined result and the count of selected lines.
+func selectByWeight(original, stripped []string, cleanupStart, maxBytes int) (string, int) {
+	type indexedLine struct {
+		idx    int
+		weight int
+		size   int
+	}
+
+	candidates := make([]indexedLine, 0, len(stripped))
+	for i, s := range stripped {
+		if cleanupStart >= 0 && i >= cleanupStart {
+			continue
+		}
+		if classifyLine(s) == lineNoise {
+			continue
+		}
+		w := classifyWeight(s)
+		candidates = append(candidates, indexedLine{idx: i, weight: w, size: len(original[i]) + 1})
+	}
+
+	// Adjacency boost: raise weight of up to adjacencyBoostSize lines that
+	// follow a critical line, so stack frames and context stay with their
+	// panic/exception header. Boost to weightError so they compete at the
+	// error tier (not critical — we don't want them to outrank fresh panics).
+	for i, c := range candidates {
+		if c.weight != weightCritical {
+			continue
+		}
+		boostTarget := c.idx + adjacencyBoostSize
+		for j := i + 1; j < len(candidates) && candidates[j].idx <= boostTarget; j++ {
+			if candidates[j].weight < weightError {
+				candidates[j].weight = weightError
+			}
+		}
+	}
+
+	// Sort by weight desc; tiebreak on later index (in CI, the last error is
+	// usually the root cause — earlier errors are often cascading consequences).
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].weight != candidates[j].weight {
+			return candidates[i].weight > candidates[j].weight
+		}
+		return candidates[i].idx > candidates[j].idx
+	})
+
+	selected := make(map[int]bool, len(candidates))
+	budget := maxBytes
+	for _, c := range candidates {
+		if c.size > budget {
+			continue
+		}
+		selected[c.idx] = true
+		budget -= c.size
+	}
+
+	// Re-emit in chronological order, inserting a truncation marker where
+	// consecutive selected indices have a gap. This prevents the LLM from
+	// inferring causality between non-adjacent log events.
+	var out []string
+	prev := -1
+	kept := 0
+	for i := range original {
+		if !selected[i] {
+			continue
+		}
+		if prev >= 0 && i > prev+1 {
+			out = append(out, truncationMarker)
+		}
+		out = append(out, original[i])
+		prev = i
+		kept++
+	}
+	return strings.Join(out, "\n"), kept
+}
+
+const truncationMarker = "... [truncated] ..."
 
 // findTrailingCleanup finds the start index of the trailing post-job cleanup
 // section. Returns -1 if not found.

--- a/pkg/logclean/weighted.go
+++ b/pkg/logclean/weighted.go
@@ -1,0 +1,86 @@
+package logclean
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Line importance weights for budget-constrained selection.
+// Higher weight = more likely to be preserved under tight budget.
+const (
+	weightNoise    = 0
+	weightDefault  = 1
+	weightWarning  = 3
+	weightError    = 5
+	weightCritical = 10
+)
+
+var criticalPrefixes = []string{
+	"panic:",
+	"Traceback",
+	"##[error]",
+}
+
+var criticalRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(?:^|\s)(?:FAIL|FAILED|Exception):`),
+	// Bun/vitest/jest lowercase marker: "(fail) TestName" — no colon.
+	regexp.MustCompile(`^\(fail\)\s`),
+}
+
+var errorRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(?:^|\s)(?:ERROR|FATAL)(?::|\s|$)`),
+	regexp.MustCompile(`(?i)(?:^|\s)error:`),
+	// Stack frames (Go, JS/TS, Python, Java, Rust)
+	regexp.MustCompile(`^\t.+\.go:\d+`),
+	regexp.MustCompile(`\([^)]+\.[jt]sx?:\d+(?::\d+)?\)`),
+	regexp.MustCompile(`File ".+", line \d+`),
+	regexp.MustCompile(`at .+\(.+\.java:\d+\)`),
+	regexp.MustCompile(`panicked at`),
+}
+
+var warningContains = []string{
+	"timed out",
+	"deadlock",
+	"OOMKilled",
+	"connection refused",
+	"connection reset",
+}
+
+var warningContainsLower = func() []string {
+	out := make([]string, len(warningContains))
+	for i, s := range warningContains {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}()
+
+// classifyWeight assigns an importance weight to a log line.
+// The line is expected to already have timestamp and leading whitespace stripped
+// and to have been confirmed as signal (classifyLine != lineNoise) by the caller.
+func classifyWeight(line string) int {
+	for _, p := range criticalPrefixes {
+		if strings.HasPrefix(line, p) {
+			return weightCritical
+		}
+	}
+	for _, re := range criticalRegexes {
+		if re.MatchString(line) {
+			return weightCritical
+		}
+	}
+
+	for _, re := range errorRegexes {
+		if re.MatchString(line) {
+			return weightError
+		}
+	}
+
+	lower := strings.ToLower(line)
+	for _, s := range warningContainsLower {
+		if strings.Contains(lower, s) {
+			return weightWarning
+		}
+	}
+
+	return weightDefault
+}

--- a/pkg/logclean/weighted_bench_test.go
+++ b/pkg/logclean/weighted_bench_test.go
@@ -1,0 +1,37 @@
+package logclean
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWeighted_SizeReduction(t *testing.T) {
+	fixtures := []string{"github_brokk.txt", "github_dms_workspace.txt", "github_monaco.txt"}
+	budgets := []int{5000, 10000, 30000, 80000}
+
+	for _, name := range fixtures {
+		data, err := os.ReadFile(filepath.Join("testdata", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		input := string(data)
+
+		for _, budget := range budgets {
+			t.Run(fmt.Sprintf("%s/budget=%d", name, budget), func(t *testing.T) {
+				_ = os.Unsetenv(weightedFlagEnv)
+				baseline, bStats := Extract(input, budget)
+
+				t.Setenv(weightedFlagEnv, "1")
+				weighted, wStats := Extract(input, budget)
+
+				t.Logf("input=%d bytes, budget=%d", len(input), budget)
+				t.Logf("  baseline: %d bytes, %d lines (dropped=%d, fallback=%v)",
+					len(baseline), bStats.OutputLines, bStats.DroppedLines, bStats.FallbackUsed)
+				t.Logf("  weighted: %d bytes, %d lines (dropped=%d, fallback=%v)",
+					len(weighted), wStats.OutputLines, wStats.DroppedLines, wStats.FallbackUsed)
+			})
+		}
+	}
+}

--- a/pkg/logclean/weighted_test.go
+++ b/pkg/logclean/weighted_test.go
@@ -1,0 +1,230 @@
+package logclean
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyWeight_Critical(t *testing.T) {
+	critical := []string{
+		"FAIL: TestLogin (0.5s)",
+		"Exception: connection refused",
+		"panic: runtime error: index out of range",
+		`Traceback (most recent call last):`,
+		"##[error]Process completed with exit code 1.",
+	}
+	for _, line := range critical {
+		assert.Equal(t, weightCritical, classifyWeight(line), "expected critical weight: %q", line)
+	}
+}
+
+func TestClassifyWeight_Error(t *testing.T) {
+	errorLines := []string{
+		"ERROR: build failed",
+		"FATAL: could not open config",
+		"\t/app/pkg/server/handler.go:42",
+		`File "/app/tests/test_auth.py", line 42`,
+		"at com.example.AppTest.testLogin(AppTest.java:42)",
+	}
+	for _, line := range errorLines {
+		assert.Equal(t, weightError, classifyWeight(line), "expected error weight: %q", line)
+	}
+}
+
+func TestClassifyWeight_Warning(t *testing.T) {
+	warnings := []string{
+		"request timed out after 30s",
+		"deadlock detected on resource pool",
+		"container OOMKilled",
+		"dial tcp: connection refused",
+	}
+	for _, line := range warnings {
+		assert.Equal(t, weightWarning, classifyWeight(line), "expected warning weight: %q", line)
+	}
+}
+
+func TestClassifyWeight_NoiseFilteredByCaller(t *testing.T) {
+	// classifyWeight's contract: caller filters noise via classifyLine first.
+	// This test documents that contract — noise lines are dropped upstream.
+	noise := []string{
+		"Current runner version: '2.333.1'",
+		"Post job cleanup.",
+		"##[group]Run actions/checkout@v6",
+	}
+	for _, line := range noise {
+		assert.Equal(t, lineNoise, classifyLine(line), "caller must filter: %q", line)
+	}
+}
+
+func TestClassifyWeight_DefaultSignal(t *testing.T) {
+	generic := []string{
+		"Building project...",
+		"Compiling src/main.ts",
+		"npm warn deprecated some-package@1.0.0",
+	}
+	for _, line := range generic {
+		assert.Equal(t, weightDefault, classifyWeight(line), "expected default weight: %q", line)
+	}
+}
+
+func TestExtract_WeightedSelection_PrefersCritical(t *testing.T) {
+	t.Setenv("HEISENBERG_LOG_WEIGHTED", "1")
+
+	// High-weight critical line buried in weight-1 filler must survive under
+	// budget pressure even when it's earlier than the filler tail.
+	var lines []string
+	lines = append(lines, "2026-04-04T10:00:00.0000000Z panic: runtime error: index out of range")
+	for i := 0; i < 100; i++ {
+		lines = append(lines, "2026-04-04T10:00:02.0000000Z Building project filler line "+strings.Repeat("x", 10))
+	}
+	input := strings.Join(lines, "\n")
+
+	// Budget large enough to fit ~2-3 lines.
+	out, _ := Extract(input, 200)
+
+	assert.Contains(t, out, "panic: runtime error", "critical weight line must survive selection pressure")
+}
+
+func TestExtract_WeightedSelection_PreservesChronologicalOrder(t *testing.T) {
+	t.Setenv("HEISENBERG_LOG_WEIGHTED", "1")
+
+	// Prepend filler so input exceeds budget; keep high-weight markers
+	// near the end so adjacency boost doesn't elevate unrelated fillers
+	// into the selection set.
+	var lines []string
+	for i := 0; i < 20; i++ {
+		lines = append(lines, "2026-04-04T10:00:00.0000000Z Building project...")
+	}
+	lines = append(lines,
+		"2026-04-04T10:00:01.0000000Z panic: first panic",
+		"2026-04-04T10:00:02.0000000Z ERROR: middle error",
+		"2026-04-04T10:00:03.0000000Z FAIL: last test",
+	)
+	input := strings.Join(lines, "\n")
+
+	out, _ := Extract(input, 300)
+
+	iPanic := strings.Index(out, "first panic")
+	iError := strings.Index(out, "middle error")
+	iFail := strings.Index(out, "last test")
+	assert.Greater(t, iPanic, -1)
+	assert.Greater(t, iError, -1)
+	assert.Greater(t, iFail, -1)
+	assert.Less(t, iPanic, iError, "panic should appear before error")
+	assert.Less(t, iError, iFail, "error should appear before fail")
+}
+
+func TestExtract_WeightedSelection_AdjacencyBoost(t *testing.T) {
+	t.Setenv("HEISENBERG_LOG_WEIGHTED", "1")
+
+	// A panic followed by stack-frame-like lines must bring its 3 neighbors
+	// along, even when unrelated high-weight lines exist elsewhere.
+	fat := strings.Repeat("x", 60)
+	var lines []string
+	// Competing unrelated ERROR lines early in the log.
+	for i := 0; i < 10; i++ {
+		lines = append(lines, "2026-04-04T10:00:00.0000000Z ERROR: unrelated "+fat)
+	}
+	// The panic we care about.
+	lines = append(lines, "2026-04-04T10:00:01.0000000Z panic: real root cause")
+	lines = append(lines, "2026-04-04T10:00:02.0000000Z goroutine 1 [running]")
+	lines = append(lines, "2026-04-04T10:00:03.0000000Z main.foo() returned bad value")
+	lines = append(lines, "2026-04-04T10:00:04.0000000Z context: more detail about failure")
+	// Filler tail.
+	for i := 0; i < 10; i++ {
+		lines = append(lines, "2026-04-04T10:00:05.0000000Z Running tests "+fat)
+	}
+	input := strings.Join(lines, "\n")
+
+	// Budget fits roughly the panic plus its 3 neighbors, but leaves room to
+	// compete with one of the unrelated ERRORs.
+	out, _ := Extract(input, 400)
+
+	assert.Contains(t, out, "panic: real root cause")
+	assert.Contains(t, out, "goroutine 1 [running]", "line immediately after panic must be boosted")
+	assert.Contains(t, out, "main.foo() returned bad value", "2nd line after panic must be boosted")
+	assert.Contains(t, out, "context: more detail", "3rd line after panic must be boosted")
+}
+
+func TestExtract_WeightedSelection_InsertsTruncationMarker(t *testing.T) {
+	t.Setenv("HEISENBERG_LOG_WEIGHTED", "1")
+
+	var lines []string
+	lines = append(lines, "2026-04-04T10:00:00.0000000Z panic: first panic")
+	for i := 0; i < 100; i++ {
+		lines = append(lines, "2026-04-04T10:00:01.0000000Z Building project filler "+strings.Repeat("x", 20))
+	}
+	lines = append(lines, "2026-04-04T10:00:02.0000000Z panic: second panic")
+	input := strings.Join(lines, "\n")
+
+	// Budget fits both panic lines but drops most filler between them.
+	out, _ := Extract(input, 200)
+
+	assert.Contains(t, out, "first panic")
+	assert.Contains(t, out, "second panic")
+	assert.Contains(t, out, "[truncated]", "gaps between non-adjacent selected lines must be marked")
+}
+
+func TestExtract_WeightedSelection_NoMarkerWhenContiguous(t *testing.T) {
+	t.Setenv("HEISENBERG_LOG_WEIGHTED", "1")
+
+	// All selected lines are adjacent — no marker needed. Use large filler
+	// so only the 3 contiguous panics fit in budget.
+	fat := strings.Repeat("x", 200)
+	var lines []string
+	lines = append(lines, "2026-04-04T10:00:00.0000000Z panic: A")
+	lines = append(lines, "2026-04-04T10:00:01.0000000Z panic: B")
+	lines = append(lines, "2026-04-04T10:00:02.0000000Z panic: C")
+	for i := 0; i < 20; i++ {
+		lines = append(lines, "2026-04-04T10:00:03.0000000Z Running tests "+fat)
+	}
+	input := strings.Join(lines, "\n")
+
+	out, _ := Extract(input, 150)
+
+	assert.Contains(t, out, "panic: A")
+	assert.Contains(t, out, "panic: B")
+	assert.Contains(t, out, "panic: C")
+	assert.NotContains(t, out, "[truncated]", "no marker when selected lines are contiguous")
+}
+
+func TestExtract_WeightedSelection_TiebreakFavorsLaterLines(t *testing.T) {
+	t.Setenv("HEISENBERG_LOG_WEIGHTED", "1")
+
+	// Two equally-weighted errors. Under budget pressure (fits one), the later
+	// one wins — in CI pipelines the last error is usually the root cause.
+	var lines []string
+	lines = append(lines, "2026-04-04T10:00:00.0000000Z panic: EARLY panic")
+	for i := 0; i < 50; i++ {
+		lines = append(lines, "2026-04-04T10:00:01.0000000Z Building project...")
+	}
+	lines = append(lines, "2026-04-04T10:00:02.0000000Z panic: LATE panic")
+	for i := 0; i < 50; i++ {
+		lines = append(lines, "2026-04-04T10:00:03.0000000Z more building output filler")
+	}
+	input := strings.Join(lines, "\n")
+
+	// Budget tight enough to fit roughly one panic line + minimal filler.
+	out, _ := Extract(input, 80)
+
+	assert.Contains(t, out, "LATE panic", "later-index critical line should win tiebreak")
+	assert.NotContains(t, out, "EARLY panic", "earlier critical line should be dropped when budget forces choice")
+}
+
+func TestExtract_WeightedSelection_FlagOff_UnchangedBehavior(t *testing.T) {
+	// Flag unset — behavior must match existing Extract.
+	var lines []string
+	for i := 0; i < 200; i++ {
+		lines = append(lines, "FAIL: TestSomething")
+	}
+	input := strings.Join(lines, "\n")
+
+	out, stats := Extract(input, 500)
+
+	// Tail truncation: output size ≤ budget, no fallback.
+	assert.LessOrEqual(t, len(out), 500)
+	assert.False(t, stats.FallbackUsed)
+	assert.Contains(t, out, "FAIL: TestSomething")
+}


### PR DESCRIPTION
## Summary

Adds per-line importance weighting (0/1/3/5/10) for budget-bound log selection in `pkg/logclean`. When the `HEISENBERG_LOG_WEIGHTED=1` env flag is set, replaces tail-truncation with weight-priority selection that preserves critical errors (`panic`, `FAIL`, `Exception`, `##[error]`) even when they appear early in the log.

**Flag defaults to OFF** — existing behavior is unchanged. This ships dormant code; activation is a separate decision once we can measure A/B impact on live eval.

Part of #58 (top-ROI item from meta issue #57).

## Design

- **Weights**: 10 (panic/FAIL/Exception/Traceback/##[error]), 5 (ERROR/FATAL/stack frames), 3 (timeout/deadlock/OOM/conn refused), 1 (default signal), 0 (noise).
- **Tiebreak later-wins**: in CI, the last error is usually the root cause; earlier errors are often cascading consequences.
- **Adjacency boost**: lines immediately following a weight-10 critical line are promoted to weight-5 so stack frames stay with their panic header.
- **Truncation markers** (`... [truncated] ...`): inserted between non-adjacent selected indices to prevent the LLM from inferring false causality between non-contiguous log events.

## Review history

Zen code review (Gemini 3 Pro) flagged 5 issues on the initial implementation. All addressed before push:
- Tiebreak direction fixed (SliceStable → Slice with reverse-index tiebreak)
- Truncation markers added
- Double regex parsing removed (classifyWeight no longer calls classifyLine)
- Adjacency boost for stack-frame adjacency
- Pre-lowercase warning substrings to avoid per-iteration allocation

## Why merge without live eval

Live smoke eval (30 cases) attempted but blocked by Gemini API 503 "high demand" errors — 5× retry backoff blew the 20-min test timeout at 8/30 cases. VCR replay can't measure input-change effects (frozen responses). Sanity diff on 3 real fixtures at the production 30KB budget shows weighted mode surfaces JUnit stack traces and failing test method names, while baseline kept only debug log noise — plausible positive signal.

Ship behind flag now, measure A/B when Gemini API stabilizes.

## Test plan

- [x] All existing `pkg/logclean` tests pass
- [x] New tests: 9 weighted-path tests covering critical preservation, chronological order, tiebreak direction, markers, adjacency boost, flag-off parity
- [x] Full `go test ./...` green
- [x] Manual diff on `pkg/logclean/testdata/*.txt` fixtures confirms reasonable output under budget pressure
- [ ] Live A/B eval on 171 cases when Gemini API load normalizes (tracked as followup in #58)

## Followups

- #58 stays open until live A/B confirms/rejects the accuracy improvement
- Separate issue needed: pre-existing bug where `logclean.go:45 TrimLeft(" \t")` strips leading tab from Go stack frames, defeating the `^\t.+\.go:\d+` signal regex