### PR TITLE
refactor(cluster): pluggable Stage pipeline + TopFrames on signatures

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,6 +1,9 @@
 package cluster
 
-import "sort"
+import (
+	"context"
+	"sort"
+)
 
 const (
 	// jaccardThreshold is the minimum similarity to merge two singleton clusters.
@@ -11,13 +14,23 @@ const (
 	maxClusters = 10
 )
 
-// ClusterFailures groups failures by error signature.
-// Phase A: exact match on normalized signature.
-// Phase B: Jaccard merge for similar singletons.
-// Returns a single-cluster result as fallback.
+// ClusterFailures groups failures by error signature using the default
+// OSS pipeline: exact match → Jaccard merge.
 func ClusterFailures(failures []FailureInfo) Result {
+	result, _ := ClusterFailuresWithStages(context.Background(), failures, JaccardStage{})
+	return result
+}
+
+// ClusterFailuresWithStages runs the clustering pipeline with a custom
+// ordered list of refinement stages. Stages run after exact-match grouping
+// and before the cluster cap. An error from any stage causes that stage's
+// output to be discarded; prior stage output is preserved.
+//
+// The returned error is always nil today; reserved for future stages that
+// need to surface fatal conditions to callers.
+func ClusterFailuresWithStages(ctx context.Context, failures []FailureInfo, stages ...Stage) (Result, error) {
 	if len(failures) == 0 {
-		return Result{Method: "single"}
+		return Result{Method: "single"}, nil
 	}
 	if len(failures) == 1 {
 		c := buildCluster(0, failures)
@@ -25,40 +38,23 @@ func ClusterFailures(failures []FailureInfo) Result {
 			Clusters:    []Cluster{c},
 			TotalFailed: 1,
 			Method:      "single",
-		}
+		}, nil
 	}
 
-	// Separate failures with/without signatures
-	var withSig, withoutSig []FailureInfo
-	for _, f := range failures {
-		if f.Signature.Category == "" {
-			withoutSig = append(withoutSig, f)
-		} else {
-			withSig = append(withSig, f)
-		}
-	}
-
-	// Phase A: exact match on Normalized string
-	groups := map[string][]FailureInfo{}
-	for _, f := range withSig {
-		key := f.Signature.Normalized
-		groups[key] = append(groups[key], f)
-	}
-
-	// Convert to cluster list
-	var clusters []Cluster
-	for _, members := range groups {
-		clusters = append(clusters, buildCluster(len(clusters), members))
-	}
-
+	withSig, withoutSig := partitionBySignature(failures)
+	clusters := exactMatchClusters(withSig)
 	method := "exact"
 
-	// Phase B: Jaccard merge for singletons
-	merged := jaccardMerge(clusters)
-	if len(merged) < len(clusters) {
-		method = "jaccard"
+	for _, stage := range stages {
+		refined, err := stage.Refine(ctx, clusters)
+		if err != nil {
+			continue
+		}
+		if len(refined) < len(clusters) {
+			method = stage.Name()
+		}
+		clusters = refined
 	}
-	clusters = merged
 
 	// Sort by size descending (largest cluster first)
 	sort.Slice(clusters, func(i, j int) bool {
@@ -73,7 +69,6 @@ func ClusterFailures(failures []FailureInfo) Result {
 		clusters = clusters[:maxClusters]
 	}
 
-	// Re-number clusters
 	for i := range clusters {
 		clusters[i].ID = i + 1
 	}
@@ -83,7 +78,31 @@ func ClusterFailures(failures []FailureInfo) Result {
 		Unclustered: withoutSig,
 		TotalFailed: len(failures),
 		Method:      method,
+	}, nil
+}
+
+func partitionBySignature(failures []FailureInfo) (withSig, withoutSig []FailureInfo) {
+	for _, f := range failures {
+		if f.Signature.Category == "" {
+			withoutSig = append(withoutSig, f)
+		} else {
+			withSig = append(withSig, f)
+		}
 	}
+	return
+}
+
+func exactMatchClusters(withSig []FailureInfo) []Cluster {
+	groups := map[string][]FailureInfo{}
+	for _, f := range withSig {
+		key := f.Signature.Normalized
+		groups[key] = append(groups[key], f)
+	}
+	var clusters []Cluster
+	for _, members := range groups {
+		clusters = append(clusters, buildCluster(len(clusters), members))
+	}
+	return clusters
 }
 
 // buildCluster creates a Cluster from a group of failures.
@@ -114,7 +133,7 @@ func jaccardMerge(clusters []Cluster) []Cluster {
 		return clusters
 	}
 
-	uf := newUnionFind(len(clusters))
+	uf := NewUnionFind(len(clusters))
 	mergeSimilarSingletons(uf, singletons, clusters)
 	return rebuildClusters(uf, clusters)
 }
@@ -129,26 +148,26 @@ func findSingletons(clusters []Cluster) []int {
 	return singletons
 }
 
-func mergeSimilarSingletons(uf *unionFind, singletons []int, clusters []Cluster) {
+func mergeSimilarSingletons(uf *UnionFind, singletons []int, clusters []Cluster) {
 	for i := 0; i < len(singletons); i++ {
 		for j := i + 1; j < len(singletons); j++ {
 			ci, cj := singletons[i], singletons[j]
-			if uf.find(ci) == uf.find(cj) {
+			if uf.Find(ci) == uf.Find(cj) {
 				continue
 			}
 			sim := jaccard(clusters[ci].Signature.Tokens, clusters[cj].Signature.Tokens)
 			if sim >= jaccardThreshold {
-				uf.union(ci, cj)
+				uf.Union(ci, cj)
 			}
 		}
 	}
 }
 
-func rebuildClusters(uf *unionFind, clusters []Cluster) []Cluster {
+func rebuildClusters(uf *UnionFind, clusters []Cluster) []Cluster {
 	grouped := map[int][]FailureInfo{}
 	groupSig := map[int]ErrorSignature{}
 	for i, c := range clusters {
-		root := uf.find(i)
+		root := uf.Find(i)
 		grouped[root] = append(grouped[root], c.Failures...)
 		if _, ok := groupSig[root]; !ok {
 			groupSig[root] = c.Signature
@@ -164,20 +183,21 @@ func rebuildClusters(uf *unionFind, clusters []Cluster) []Cluster {
 	return result
 }
 
-// unionFind is a simple disjoint-set data structure with path compression.
-type unionFind struct {
+// UnionFind is a simple disjoint-set data structure with path compression.
+type UnionFind struct {
 	parent []int
 }
 
-func newUnionFind(n int) *unionFind {
+func NewUnionFind(n int) *UnionFind {
 	parent := make([]int, n)
 	for i := range parent {
 		parent[i] = i
 	}
-	return &unionFind{parent: parent}
+	return &UnionFind{parent: parent}
 }
 
-func (uf *unionFind) find(x int) int {
+// Find returns the root of the set containing x, with path compression.
+func (uf *UnionFind) Find(x int) int {
 	for uf.parent[x] != x {
 		uf.parent[x] = uf.parent[uf.parent[x]]
 		x = uf.parent[x]
@@ -185,8 +205,9 @@ func (uf *unionFind) find(x int) int {
 	return x
 }
 
-func (uf *unionFind) union(a, b int) {
-	ra, rb := uf.find(a), uf.find(b)
+// Union merges the sets containing a and b.
+func (uf *UnionFind) Union(a, b int) {
+	ra, rb := uf.Find(a), uf.Find(b)
 	if ra != rb {
 		uf.parent[rb] = ra
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -191,13 +191,13 @@ func TestFindSingletons(t *testing.T) {
 }
 
 func TestUnionFind(t *testing.T) {
-	uf := newUnionFind(5)
-	uf.union(0, 1)
-	uf.union(2, 3)
-	uf.union(1, 3)
+	uf := NewUnionFind(5)
+	uf.Union(0, 1)
+	uf.Union(2, 3)
+	uf.Union(1, 3)
 
-	assert.Equal(t, uf.find(0), uf.find(3), "0,1,2,3 should be in same set")
-	assert.NotEqual(t, uf.find(0), uf.find(4), "4 should be separate")
+	assert.Equal(t, uf.Find(0), uf.Find(3), "0,1,2,3 should be in same set")
+	assert.NotEqual(t, uf.Find(0), uf.Find(4), "4 should be separate")
 }
 
 // repeatWord returns a unique word for index i.

--- a/pkg/cluster/signature.go
+++ b/pkg/cluster/signature.go
@@ -6,9 +6,15 @@ import (
 	"unicode"
 )
 
-// maxLogTail is the number of bytes from the end of a log to scan for errors.
-// Most CI failures appear near the end of the output.
-const maxLogTail = 30000
+const (
+	// maxLogTail is the number of bytes from the end of a log to scan for errors.
+	// Most CI failures appear near the end of the output.
+	maxLogTail = 30000
+
+	// maxTopFrames caps the distinct stack-frame locations captured per signature.
+	// Used by semantic clustering to compare top-of-stack context.
+	maxTopFrames = 3
+)
 
 // GitHub Actions timestamp prefix: 2024-01-15T10:30:00.1234567Z
 var timestampRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?`)
@@ -128,14 +134,7 @@ func tryStackTrace(text string) ErrorSignature {
 			}
 			m := matches[idx]
 			raw := m[0]
-			location := m[1]
-			if len(m) > 2 {
-				// Python: File + line combined
-				location = m[1] + ":" + m[2]
-			}
-			// Strip directory, keep filename:line
-			parts := strings.Split(location, "/")
-			short := parts[len(parts)-1]
+			short := shortFrame(m)
 
 			norm := normalize(short)
 			return ErrorSignature{
@@ -143,10 +142,41 @@ func tryStackTrace(text string) ErrorSignature {
 				Normalized: norm,
 				RawExcerpt: raw,
 				Tokens:     tokenize(norm),
+				TopFrames:  collectTopFrames(matches),
 			}
 		}
 	}
 	return ErrorSignature{}
+}
+
+// shortFrame extracts the filename:line from a stack-trace regex match.
+func shortFrame(m []string) string {
+	location := m[1]
+	if len(m) > 2 {
+		// Python: File + line combined
+		location = m[1] + ":" + m[2]
+	}
+	parts := strings.Split(location, "/")
+	return parts[len(parts)-1]
+}
+
+// collectTopFrames returns up to maxTopFrames distinct short frame locations
+// in log order.
+func collectTopFrames(matches [][]string) []string {
+	seen := make(map[string]bool, maxTopFrames)
+	var frames []string
+	for _, m := range matches {
+		f := shortFrame(m)
+		if f == "" || seen[f] {
+			continue
+		}
+		seen[f] = true
+		frames = append(frames, f)
+		if len(frames) >= maxTopFrames {
+			break
+		}
+	}
+	return frames
 }
 
 func tryErrorMessage(text string) ErrorSignature {

--- a/pkg/cluster/signature_test.go
+++ b/pkg/cluster/signature_test.go
@@ -8,6 +8,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractSignature_TopFrames_Go(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z goroutine 1 [running]:
+2026-03-29T10:00:00.1234567Z main.init.func1()
+2026-03-29T10:00:00.1234567Z 	/home/runner/work/proj/main.go:42 +0x1a4
+2026-03-29T10:00:00.1234567Z main.main()
+2026-03-29T10:00:00.1234567Z 	/home/runner/work/proj/main.go:10 +0x20
+2026-03-29T10:00:00.1234567Z 	/home/runner/work/proj/config.go:88 +0x10`
+
+	sig := ExtractSignature(log)
+	require.Equal(t, "stack_trace", sig.Category)
+	require.NotEmpty(t, sig.TopFrames)
+	assert.LessOrEqual(t, len(sig.TopFrames), 3, "cap at 3 frames")
+	// First frame (crash site) must always be present.
+	assert.Contains(t, sig.TopFrames[0], "main.go:42")
+}
+
+func TestExtractSignature_TopFrames_Python(t *testing.T) {
+	log := `2026-03-29T10:00:00.1234567Z Traceback (most recent call last):
+2026-03-29T10:00:00.1234567Z   File "/app/tests/helpers.py", line 10, in setup
+2026-03-29T10:00:00.1234567Z   File "/app/tests/test_login.py", line 42, in test_login
+2026-03-29T10:00:00.1234567Z   File "/app/tests/shared.py", line 88, in assert_status
+2026-03-29T10:00:00.1234567Z AssertionError: assert 500 == 200`
+
+	sig := ExtractSignature(log)
+	require.Equal(t, "stack_trace", sig.Category)
+	require.NotEmpty(t, sig.TopFrames)
+	// TopFrames should contain distinct filenames (up to 3).
+	seen := map[string]bool{}
+	for _, f := range sig.TopFrames {
+		seen[f] = true
+	}
+	assert.Equal(t, len(sig.TopFrames), len(seen), "frames must be distinct")
+}
+
+func TestExtractSignature_TopFrames_EmptyForNonStackTrace(t *testing.T) {
+	log := `Process completed with exit code 2.`
+	sig := ExtractSignature(log)
+	assert.Empty(t, sig.TopFrames, "non-stack-trace signatures have no frames")
+}
+
 func TestExtractSignature_ExitCode(t *testing.T) {
 	log := `2026-03-29T10:00:00.1234567Z Running tests...
 2026-03-29T10:00:05.1234567Z FAIL

--- a/pkg/cluster/stages.go
+++ b/pkg/cluster/stages.go
@@ -1,0 +1,25 @@
+package cluster
+
+import "context"
+
+// Stage refines a cluster list. Stages run after exact-match grouping
+// and before the cluster cap. The semantic clustering feature plugs in
+// as a Stage.
+//
+// Contract: Refine never increases the cluster count — stages only merge.
+// On error, Refine must return the input clusters unchanged so the pipeline
+// degrades gracefully.
+type Stage interface {
+	Name() string
+	Refine(ctx context.Context, clusters []Cluster) ([]Cluster, error)
+}
+
+// JaccardStage merges singleton clusters with high Jaccard similarity on tokens.
+// This is the default OSS stage.
+type JaccardStage struct{}
+
+func (JaccardStage) Name() string { return "jaccard" }
+
+func (JaccardStage) Refine(_ context.Context, clusters []Cluster) ([]Cluster, error) {
+	return jaccardMerge(clusters), nil
+}

--- a/pkg/cluster/stages_test.go
+++ b/pkg/cluster/stages_test.go
@@ -1,0 +1,130 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mergeAllStage unconditionally collapses all clusters into one. Useful for
+// testing stage plumbing without depending on real refinement logic.
+type mergeAllStage struct{ name string }
+
+func (m mergeAllStage) Name() string { return m.name }
+
+func (mergeAllStage) Refine(_ context.Context, clusters []Cluster) ([]Cluster, error) {
+	if len(clusters) <= 1 {
+		return clusters, nil
+	}
+	var all []FailureInfo
+	for _, c := range clusters {
+		all = append(all, c.Failures...)
+	}
+	return []Cluster{buildCluster(0, all)}, nil
+}
+
+// noopStage leaves clusters untouched. Used to verify method attribution
+// only updates when a stage actually reduces the cluster count.
+type noopStage struct{ name string }
+
+func (n noopStage) Name() string { return n.name }
+
+func (noopStage) Refine(_ context.Context, clusters []Cluster) ([]Cluster, error) {
+	return clusters, nil
+}
+
+// erroringStage returns an error. The pipeline must discard its output.
+type erroringStage struct{}
+
+func (erroringStage) Name() string { return "erroring" }
+
+func (erroringStage) Refine(_ context.Context, _ []Cluster) ([]Cluster, error) {
+	return nil, errors.New("boom")
+}
+
+func TestClusterFailuresWithStages_NoStages_UsesExactOnly(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, testNameA, sig("error_message", msgConnectionRefused)),
+		fail(2, testNameB, sig("error_message", "other error")),
+	}
+
+	result, err := ClusterFailuresWithStages(context.Background(), failures)
+
+	require.NoError(t, err)
+	assert.Len(t, result.Clusters, 2, "without stages, only exact match groups apply")
+	assert.Equal(t, "exact", result.Method)
+}
+
+func TestClusterFailuresWithStages_StageNameWinsWhenItMerges(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, testNameA, sig("error_message", "a")),
+		fail(2, testNameB, sig("error_message", "b")),
+	}
+
+	result, err := ClusterFailuresWithStages(context.Background(), failures, mergeAllStage{name: "merge-all"})
+
+	require.NoError(t, err)
+	assert.Len(t, result.Clusters, 1)
+	assert.Equal(t, "merge-all", result.Method)
+}
+
+func TestClusterFailuresWithStages_NoopStage_KeepsExactMethod(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, testNameA, sig("error_message", "a")),
+		fail(2, testNameB, sig("error_message", "b")),
+	}
+
+	result, err := ClusterFailuresWithStages(context.Background(), failures, noopStage{name: "noop"})
+
+	require.NoError(t, err)
+	assert.Len(t, result.Clusters, 2)
+	assert.Equal(t, "exact", result.Method, "method only changes when cluster count drops")
+}
+
+func TestClusterFailuresWithStages_ErroringStage_Degrades(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, testNameA, sig("error_message", "a")),
+		fail(2, testNameB, sig("error_message", "b")),
+	}
+
+	result, err := ClusterFailuresWithStages(context.Background(), failures, erroringStage{})
+
+	require.NoError(t, err, "stage errors must not fail the whole pipeline")
+	assert.Len(t, result.Clusters, 2, "erroring stage output is discarded")
+	assert.Equal(t, "exact", result.Method)
+}
+
+func TestClusterFailuresWithStages_MultipleStages_RunInOrder(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, testNameA, sig("error_message", "a")),
+		fail(2, testNameB, sig("error_message", "b")),
+	}
+
+	result, err := ClusterFailuresWithStages(
+		context.Background(),
+		failures,
+		noopStage{name: "first"},
+		mergeAllStage{name: "second"},
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, result.Clusters, 1)
+	assert.Equal(t, "second", result.Method, "later stage's name wins when it merges")
+}
+
+func TestJaccardStage_RefineMatchesLegacyBehavior(t *testing.T) {
+	failures := []FailureInfo{
+		fail(1, "a", sig("error_message", "authentication failed for user alice")),
+		fail(2, "b", sig("error_message", "authentication failed for user bob")),
+	}
+
+	legacy := ClusterFailures(failures)
+	viaStage, err := ClusterFailuresWithStages(context.Background(), failures, JaccardStage{})
+
+	require.NoError(t, err)
+	assert.Equal(t, len(legacy.Clusters), len(viaStage.Clusters))
+	assert.Equal(t, legacy.Method, viaStage.Method)
+}

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -9,6 +9,7 @@ type ErrorSignature struct {
 	Normalized string   // normalized error string for comparison
 	RawExcerpt string   // original text excerpt (for LLM context)
 	Tokens     []string // tokenized form for Jaccard similarity
+	TopFrames  []string // up to 3 distinct stack frame locations (stack_trace only)
 }
 
 // FailureInfo holds extracted failure data for one job.


### PR DESCRIPTION
## Summary

Pure refactor of `pkg/cluster` to extract the post-exact-match refinement phase into a `Stage` interface. Unblocks #59 (semantic clustering) without altering any current behavior.

**Zero behavior change** — all existing tests pass unmodified; new tests cover the new plumbing.

## What changed

- `Stage` interface with `Name()` + `Refine(ctx, clusters)`. Contract: stages only merge (never increase cluster count); errors are swallowed so the pipeline degrades gracefully to the prior stage's output.
- `JaccardStage` wraps the existing `jaccardMerge` as the default OSS stage.
- New `ClusterFailuresWithStages(ctx, failures, stages...)` as the general entry point. `ClusterFailures(failures)` keeps its current signature and delegates with `JaccardStage{}`.
- `ErrorSignature.TopFrames []string` — up to 3 distinct stack frame locations, used by the semantic stage (next PR) to build embedding text.
- `UnionFind`, `NewUnionFind`, `Find`, `Union` exported so `ee/cluster` can reuse them in PR 2.

## Why this split

Per plan for #59: the semantic clustering layer (pgvector + Gemini embeddings) is EE-only, but the interface stays OSS so `pkg/analysis` never imports `ee/`. This PR lands the OSS-side refactor; PR 2 adds `ee/cluster.SemanticStage`; PR 3 tunes the similarity threshold on eval and flips the default.

## Test plan

- [x] `go test ./pkg/cluster/...` — all existing tests pass unchanged
- [x] 6 new tests for `ClusterFailuresWithStages` (no stages, merging stage, noop stage, erroring stage, stage ordering, JaccardStage-matches-legacy)
- [x] 3 new tests for `TopFrames` (Go multi-frame, Python dedup, empty-on-non-stack-trace)
- [x] `go test ./...` green

Part of #59. PR 1 of 3.