### PR TITLE
feat(semcluster): semantic clustering stage behind flag

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -21,11 +21,13 @@ import (
 	"github.com/kamilpajak/heisenberg/pkg/analysis"
 	"github.com/kamilpajak/heisenberg/pkg/azure"
 	"github.com/kamilpajak/heisenberg/pkg/ci"
+	"github.com/kamilpajak/heisenberg/pkg/cluster"
 	"github.com/kamilpajak/heisenberg/pkg/config"
 	"github.com/kamilpajak/heisenberg/pkg/github"
 	"github.com/kamilpajak/heisenberg/pkg/llm"
 	"github.com/kamilpajak/heisenberg/pkg/patterns"
 	"github.com/kamilpajak/heisenberg/pkg/saas"
+	"github.com/kamilpajak/heisenberg/pkg/semcluster"
 	"github.com/kamilpajak/heisenberg/pkg/trace"
 	"github.com/spf13/cobra"
 )
@@ -301,6 +303,7 @@ func run(cmd *cobra.Command, args []string) error {
 		CI:             ciProvider,
 		GoogleAPIKey:   cfg.GoogleAPIKey,
 		PatternMatcher: matcher,
+		ClusterStages:  buildClusterStages(cfg.GoogleAPIKey),
 	})
 	if err != nil {
 		textEmitter.MarkFailed()
@@ -960,4 +963,27 @@ func serve(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return nil
+}
+
+// buildClusterStages returns optional post-Jaccard refinement stages.
+// SemanticStage is opt-in via HEISENBERG_SEMANTIC_CLUSTERING=1 and requires
+// a Gemini API key. Defaults to no extra stages.
+func buildClusterStages(apiKey string) []cluster.Stage {
+	if os.Getenv("HEISENBERG_SEMANTIC_CLUSTERING") != "1" {
+		return nil
+	}
+	if apiKey == "" {
+		return nil
+	}
+	threshold := 0.90
+	if v := os.Getenv("HEISENBERG_SEMANTIC_CLUSTER_THRESHOLD"); v != "" {
+		if parsed, err := strconv.ParseFloat(v, 64); err == nil {
+			threshold = parsed
+		}
+	}
+	return []cluster.Stage{semcluster.SemanticStage{
+		Embedder:  semcluster.NewGeminiEmbedder(apiKey),
+		Threshold: threshold,
+		MaxPairs:  50,
+	}}
 }

--- a/pkg/analysis/run.go
+++ b/pkg/analysis/run.go
@@ -27,6 +27,7 @@ type Params struct {
 	GoogleAPIKey   string                  // Google API key override (empty = env var)
 	PatternMatcher patterns.PatternMatcher // nil = no pattern matching
 	LLMOptions     []llm.ClientOption      // Optional LLM client settings (e.g., VCR HTTP client)
+	ClusterStages  []cluster.Stage         // Optional refinement stages after Jaccard (e.g., semantic)
 }
 
 // Run executes the full analysis pipeline: resolve run ID, fetch metadata, and
@@ -154,8 +155,10 @@ func runClustered(ctx context.Context, p Params,
 	// Fetch logs for all failed jobs in parallel
 	failures := fetchFailureLogs(ctx, p, failedJobs)
 
-	// Cluster by error signature
-	cr := cluster.ClusterFailures(failures)
+	// Cluster by error signature. JaccardStage always runs; extra stages
+	// (e.g., SemanticStage from ee/cluster) may be injected via Params.
+	stages := append([]cluster.Stage{cluster.JaccardStage{}}, p.ClusterStages...)
+	cr, _ := cluster.ClusterFailuresWithStages(ctx, failures, stages...)
 
 	// If clustering produced 1 cluster or failed, fall back to single path
 	if len(cr.Clusters) <= 1 {

--- a/pkg/semcluster/antonym.go
+++ b/pkg/semcluster/antonym.go
@@ -1,0 +1,67 @@
+package semcluster
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// antonymPairs lists word pairs whose presence on opposite sides of a
+// potential merge vetoes the merge. Embedding models conflate polarity
+// ("test passed" vs "test failed" can score above 0.85) so we gate on
+// explicit antonymy.
+//
+// Left-side tokens are positive/success outcomes; right-side tokens are
+// negative/failure outcomes. Order doesn't matter for the veto — we check
+// both directions.
+var antonymPairs = [][2]string{
+	{"pass", "fail"},
+	{"passed", "failed"},
+	{"succeed", "fail"},
+	{"succeeded", "failed"},
+	{"complete", "fail"},
+	{"completed", "failed"},
+	{"ok", "error"},
+	{"accepted", "refused"},
+	{"accepted", "rejected"},
+	{"allowed", "denied"},
+	{"found", "missing"},
+	{"up", "down"},
+}
+
+var antonymRegexOnce sync.Once
+var antonymRegex map[string]*regexp.Regexp
+
+func antonymWordRegex(word string) *regexp.Regexp {
+	antonymRegexOnce.Do(func() {
+		antonymRegex = make(map[string]*regexp.Regexp, len(antonymPairs)*2)
+	})
+	if r, ok := antonymRegex[word]; ok {
+		return r
+	}
+	r := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(word) + `\b`)
+	antonymRegex[word] = r
+	return r
+}
+
+// antonymGuardrail returns true if a and b contain opposite-polarity
+// keywords from antonymPairs, blocking a candidate semantic merge.
+func antonymGuardrail(a, b string) bool {
+	for _, pair := range antonymPairs {
+		pos, neg := pair[0], pair[1]
+		if hasWord(a, pos) && hasWord(b, neg) {
+			return true
+		}
+		if hasWord(a, neg) && hasWord(b, pos) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWord(s, word string) bool {
+	if !strings.Contains(strings.ToLower(s), strings.ToLower(word)) {
+		return false
+	}
+	return antonymWordRegex(word).MatchString(s)
+}

--- a/pkg/semcluster/antonym_test.go
+++ b/pkg/semcluster/antonym_test.go
@@ -1,0 +1,55 @@
+package semcluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAntonymGuardrail_BlocksOppositeOutcomes(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"pass vs fail", "test passed", "test failed"},
+		{"succeed vs fail", "build succeeded", "build failed"},
+		{"complete vs fail", "job completed", "job failed"},
+		{"ok vs error", "status: ok", "status: error"},
+		{"connect vs refuse", "connection accepted", "connection refused"},
+		{"accept vs reject", "request accepted", "request rejected"},
+		{"allow vs deny", "access allowed", "access denied"},
+		{"found vs missing", "file found", "file missing"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, antonymGuardrail(tc.a, tc.b), "must block merge: %q vs %q", tc.a, tc.b)
+			assert.True(t, antonymGuardrail(tc.b, tc.a), "must block merge (reverse): %q vs %q", tc.b, tc.a)
+		})
+	}
+}
+
+func TestAntonymGuardrail_AllowsSamePolarity(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"both failed different detail", "connection refused on 5432", "connection refused on 5433"},
+		{"both passed", "all tests passed", "integration tests passed"},
+		{"both errors", "error: file not found", "error: permission denied"},
+		{"unrelated", "compiler optimization level 2", "compiler optimization level 3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.False(t, antonymGuardrail(tc.a, tc.b), "must allow merge: %q vs %q", tc.a, tc.b)
+		})
+	}
+}
+
+func TestAntonymGuardrail_CaseInsensitive(t *testing.T) {
+	assert.True(t, antonymGuardrail("Test PASSED", "test failed"))
+}
+
+func TestAntonymGuardrail_RequiresWordBoundary(t *testing.T) {
+	// "passed" in "compassed" should NOT trigger a false antonym match.
+	assert.False(t, antonymGuardrail("compassed value", "test failed"))
+}

--- a/pkg/semcluster/antonym_test.go
+++ b/pkg/semcluster/antonym_test.go
@@ -6,12 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testFailedLiteral = "test failed"
+
 func TestAntonymGuardrail_BlocksOppositeOutcomes(t *testing.T) {
 	cases := []struct {
 		name string
 		a, b string
 	}{
-		{"pass vs fail", "test passed", "test failed"},
+		{"pass vs fail", "test passed", testFailedLiteral},
 		{"succeed vs fail", "build succeeded", "build failed"},
 		{"complete vs fail", "job completed", "job failed"},
 		{"ok vs error", "status: ok", "status: error"},
@@ -46,10 +48,10 @@ func TestAntonymGuardrail_AllowsSamePolarity(t *testing.T) {
 }
 
 func TestAntonymGuardrail_CaseInsensitive(t *testing.T) {
-	assert.True(t, antonymGuardrail("Test PASSED", "test failed"))
+	assert.True(t, antonymGuardrail("Test PASSED", testFailedLiteral))
 }
 
 func TestAntonymGuardrail_RequiresWordBoundary(t *testing.T) {
 	// "passed" in "compassed" should NOT trigger a false antonym match.
-	assert.False(t, antonymGuardrail("compassed value", "test failed"))
+	assert.False(t, antonymGuardrail("compassed value", testFailedLiteral))
 }

--- a/pkg/semcluster/cosine.go
+++ b/pkg/semcluster/cosine.go
@@ -1,0 +1,26 @@
+// Package semcluster provides semantic failure clustering on top of the
+// pkg/cluster pipeline. Near-duplicate failures (same root cause, slightly
+// different error text) can be collapsed into one cluster using embedding
+// similarity with an antonym guardrail against false merges.
+package semcluster
+
+import "math"
+
+// cosineSimilarity returns the cosine similarity of two equal-length vectors.
+// Returns 0 for length mismatch or zero-magnitude inputs.
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, magA, magB float64
+	for i := range a {
+		x, y := float64(a[i]), float64(b[i])
+		dot += x * y
+		magA += x * x
+		magB += y * y
+	}
+	if magA == 0 || magB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(magA) * math.Sqrt(magB))
+}

--- a/pkg/semcluster/cosine_test.go
+++ b/pkg/semcluster/cosine_test.go
@@ -1,0 +1,44 @@
+package semcluster
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCosineSimilarity_IdenticalVectors(t *testing.T) {
+	v := []float32{1, 2, 3}
+	assert.InDelta(t, 1.0, cosineSimilarity(v, v), 1e-6)
+}
+
+func TestCosineSimilarity_OrthogonalVectors(t *testing.T) {
+	a := []float32{1, 0, 0}
+	b := []float32{0, 1, 0}
+	assert.InDelta(t, 0.0, cosineSimilarity(a, b), 1e-6)
+}
+
+func TestCosineSimilarity_OppositeVectors(t *testing.T) {
+	a := []float32{1, 2, 3}
+	b := []float32{-1, -2, -3}
+	assert.InDelta(t, -1.0, cosineSimilarity(a, b), 1e-6)
+}
+
+func TestCosineSimilarity_DifferentLengths_Zero(t *testing.T) {
+	a := []float32{1, 2, 3}
+	b := []float32{1, 2}
+	assert.Equal(t, 0.0, cosineSimilarity(a, b))
+}
+
+func TestCosineSimilarity_ZeroVector_Zero(t *testing.T) {
+	a := []float32{0, 0, 0}
+	b := []float32{1, 2, 3}
+	assert.Equal(t, 0.0, cosineSimilarity(a, b))
+}
+
+func TestCosineSimilarity_KnownCase(t *testing.T) {
+	// Two unit vectors at 60° → cos(60°) = 0.5
+	a := []float32{1, 0}
+	b := []float32{float32(math.Cos(math.Pi / 3)), float32(math.Sin(math.Pi / 3))}
+	assert.InDelta(t, 0.5, cosineSimilarity(a, b), 1e-6)
+}

--- a/pkg/semcluster/gemini.go
+++ b/pkg/semcluster/gemini.go
@@ -1,0 +1,113 @@
+package semcluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// GeminiEmbedder is a minimal HTTP-backed Embedder for Google's Gemini
+// embedding API. It intentionally duplicates a slice of
+// ee/patterns.EmbeddingClient so pkg/semcluster stays importable from OSS
+// binaries without crossing the license boundary.
+type GeminiEmbedder struct {
+	apiKey     string
+	baseURL    string
+	model      string
+	dimensions int
+	httpClient *http.Client
+}
+
+// NewGeminiEmbedder returns a GeminiEmbedder using apiKey for authentication.
+// Default model: gemini-embedding-001 at 768 dimensions.
+func NewGeminiEmbedder(apiKey string) *GeminiEmbedder {
+	return &GeminiEmbedder{
+		apiKey:     apiKey,
+		baseURL:    "https://generativelanguage.googleapis.com/v1beta",
+		model:      "gemini-embedding-001",
+		dimensions: 768,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// WithHTTPClient overrides the HTTP client (used for VCR in tests).
+func (e *GeminiEmbedder) WithHTTPClient(c *http.Client) *GeminiEmbedder {
+	e.httpClient = c
+	return e
+}
+
+type geminiEmbedRequest struct {
+	Model                string             `json:"model"`
+	Content              geminiEmbedContent `json:"content"`
+	OutputDimensionality int                `json:"outputDimensionality,omitempty"`
+}
+
+type geminiEmbedContent struct {
+	Parts []geminiEmbedPart `json:"parts"`
+}
+
+type geminiEmbedPart struct {
+	Text string `json:"text"`
+}
+
+type geminiEmbedResponse struct {
+	Embedding struct {
+		Values []float32 `json:"values"`
+	} `json:"embedding"`
+	Error *geminiEmbedError `json:"error,omitempty"`
+}
+
+type geminiEmbedError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Embed satisfies the Embedder interface.
+func (e *GeminiEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	reqBody := geminiEmbedRequest{
+		Model:                fmt.Sprintf("models/%s", e.model),
+		Content:              geminiEmbedContent{Parts: []geminiEmbedPart{{Text: text}}},
+		OutputDimensionality: e.dimensions,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal embedding request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/models/%s:embedContent?key=%s", e.baseURL, e.model, e.apiKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create embedding request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding API call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read embedding response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("embedding API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result geminiEmbedResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal embedding response: %w", err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("embedding API error %d: %s", result.Error.Code, result.Error.Message)
+	}
+	if len(result.Embedding.Values) == 0 {
+		return nil, fmt.Errorf("embedding API returned empty vector")
+	}
+	return result.Embedding.Values, nil
+}

--- a/pkg/semcluster/gemini_test.go
+++ b/pkg/semcluster/gemini_test.go
@@ -1,0 +1,152 @@
+package semcluster
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEmbedder(handler http.HandlerFunc) (*GeminiEmbedder, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	e := NewGeminiEmbedder("test-key")
+	e.baseURL = srv.URL
+	e.httpClient = srv.Client()
+	return e, srv
+}
+
+func TestGeminiEmbedder_Success(t *testing.T) {
+	e, srv := newTestEmbedder(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "embedContent")
+		assert.Equal(t, "test-key", r.URL.Query().Get("key"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var body geminiEmbedRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "hello", body.Content.Parts[0].Text)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiEmbedResponse{
+			Embedding: struct {
+				Values []float32 `json:"values"`
+			}{Values: []float32{0.1, 0.2, 0.3}},
+		})
+	})
+	defer srv.Close()
+
+	vec, err := e.Embed(context.Background(), "hello")
+
+	require.NoError(t, err)
+	assert.Equal(t, []float32{0.1, 0.2, 0.3}, vec)
+}
+
+func TestGeminiEmbedder_APIError_StatusCode(t *testing.T) {
+	e, srv := newTestEmbedder(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "quota exceeded", http.StatusTooManyRequests)
+	})
+	defer srv.Close()
+
+	_, err := e.Embed(context.Background(), "hello")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "429")
+	assert.Contains(t, err.Error(), "quota exceeded")
+}
+
+func TestGeminiEmbedder_APIError_StructuredError(t *testing.T) {
+	e, srv := newTestEmbedder(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiEmbedResponse{
+			Error: &geminiEmbedError{Code: 400, Message: "bad request"},
+		})
+	})
+	defer srv.Close()
+
+	_, err := e.Embed(context.Background(), "hello")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "bad request")
+}
+
+func TestGeminiEmbedder_EmptyVector(t *testing.T) {
+	e, srv := newTestEmbedder(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"embedding":{"values":[]}}`))
+	})
+	defer srv.Close()
+
+	_, err := e.Embed(context.Background(), "hello")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty vector")
+}
+
+func TestGeminiEmbedder_MalformedJSON(t *testing.T) {
+	e, srv := newTestEmbedder(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	})
+	defer srv.Close()
+
+	_, err := e.Embed(context.Background(), "hello")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+func TestGeminiEmbedder_NetworkError(t *testing.T) {
+	e, srv := newTestEmbedder(func(_ http.ResponseWriter, _ *http.Request) {})
+	srv.Close() // force connection refused
+
+	_, err := e.Embed(context.Background(), "hello")
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "embedding api call")
+}
+
+func TestGeminiEmbedder_ContextCancelled(t *testing.T) {
+	e, srv := newTestEmbedder(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := e.Embed(ctx, "hello")
+
+	require.Error(t, err)
+}
+
+func TestGeminiEmbedder_InvalidBaseURL(t *testing.T) {
+	e := NewGeminiEmbedder("test-key")
+	e.baseURL = "://invalid"
+
+	_, err := e.Embed(context.Background(), "hello")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create embedding request")
+}
+
+func TestNewGeminiEmbedder_Defaults(t *testing.T) {
+	e := NewGeminiEmbedder("abc")
+	assert.Equal(t, "abc", e.apiKey)
+	assert.Equal(t, 768, e.dimensions)
+	assert.Equal(t, "gemini-embedding-001", e.model)
+	assert.Contains(t, e.baseURL, "generativelanguage.googleapis.com")
+	assert.NotNil(t, e.httpClient)
+}
+
+func TestGeminiEmbedder_WithHTTPClient(t *testing.T) {
+	e := NewGeminiEmbedder("abc")
+	custom := &http.Client{}
+	returned := e.WithHTTPClient(custom)
+	assert.Same(t, e, returned, "WithHTTPClient returns receiver for chaining")
+	assert.Same(t, custom, e.httpClient)
+}

--- a/pkg/semcluster/semantic.go
+++ b/pkg/semcluster/semantic.go
@@ -99,20 +99,24 @@ func (s SemanticStage) mergeByCosine(uf *pkgcluster.UnionFind, clusters []pkgclu
 				return
 			}
 			comparisons++
-			ci, cj := singletons[i], singletons[j]
-			if uf.Find(ci) == uf.Find(cj) {
-				continue
+			if s.shouldMerge(uf, clusters, singletons[i], singletons[j], embeddings) {
+				uf.Union(singletons[i], singletons[j])
 			}
-			sim := cosineSimilarity(embeddings[ci], embeddings[cj])
-			if sim < s.Threshold {
-				continue
-			}
-			if antonymGuardrail(clusters[ci].Signature.RawExcerpt, clusters[cj].Signature.RawExcerpt) {
-				continue
-			}
-			uf.Union(ci, cj)
 		}
 	}
+}
+
+func (s SemanticStage) shouldMerge(uf *pkgcluster.UnionFind, clusters []pkgcluster.Cluster, ci, cj int, embeddings map[int][]float32) bool {
+	if uf.Find(ci) == uf.Find(cj) {
+		return false
+	}
+	if cosineSimilarity(embeddings[ci], embeddings[cj]) < s.Threshold {
+		return false
+	}
+	if antonymGuardrail(clusters[ci].Signature.RawExcerpt, clusters[cj].Signature.RawExcerpt) {
+		return false
+	}
+	return true
 }
 
 func rebuild(uf *pkgcluster.UnionFind, clusters []pkgcluster.Cluster) []pkgcluster.Cluster {

--- a/pkg/semcluster/semantic.go
+++ b/pkg/semcluster/semantic.go
@@ -1,0 +1,145 @@
+package semcluster
+
+import (
+	"context"
+	"sync"
+
+	pkgcluster "github.com/kamilpajak/heisenberg/pkg/cluster"
+)
+
+// Embedder generates vector embeddings for text. Implemented by
+// ee/patterns.EmbeddingClient.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+// SemanticStage is a pkg/cluster.Stage that merges singleton clusters
+// whose embedding-space cosine similarity exceeds Threshold, subject to
+// the antonym guardrail.
+//
+// Only singletons participate — multi-member clusters already have
+// grouping evidence and are left untouched.
+type SemanticStage struct {
+	Embedder  Embedder
+	Threshold float64
+	// MaxPairs caps total pairwise comparisons to avoid O(n²) embedding
+	// calls on runs with many singletons. 0 = no cap.
+	MaxPairs int
+}
+
+// Name implements pkg/cluster.Stage.
+func (SemanticStage) Name() string { return "semantic" }
+
+// Refine implements pkg/cluster.Stage. Always returns nil error — embedder
+// failures degrade to the input cluster list.
+func (s SemanticStage) Refine(ctx context.Context, clusters []pkgcluster.Cluster) ([]pkgcluster.Cluster, error) {
+	singletons := findSingletonIndices(clusters)
+	if len(singletons) < 2 {
+		return clusters, nil
+	}
+
+	embeddings, ok := s.embedSingletons(ctx, clusters, singletons)
+	if !ok {
+		return clusters, nil
+	}
+
+	uf := pkgcluster.NewUnionFind(len(clusters))
+	s.mergeByCosine(uf, clusters, singletons, embeddings)
+	return rebuild(uf, clusters), nil
+}
+
+func findSingletonIndices(clusters []pkgcluster.Cluster) []int {
+	var out []int
+	for i, c := range clusters {
+		if len(c.Failures) == 1 {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// embedSingletons returns embeddings keyed by the singleton index in clusters.
+// Returns (nil, false) if any embedding call fails — signals the caller to skip the stage.
+func (s SemanticStage) embedSingletons(ctx context.Context, clusters []pkgcluster.Cluster, singletons []int) (map[int][]float32, bool) {
+	type result struct {
+		idx int
+		vec []float32
+		err error
+	}
+
+	results := make(chan result, len(singletons))
+	var wg sync.WaitGroup
+	for _, idx := range singletons {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			text := ComputeClusterEmbeddingText(clusters[i].Signature)
+			vec, err := s.Embedder.Embed(ctx, text)
+			results <- result{idx: i, vec: vec, err: err}
+		}(idx)
+	}
+	wg.Wait()
+	close(results)
+
+	out := make(map[int][]float32, len(singletons))
+	for r := range results {
+		if r.err != nil {
+			return nil, false
+		}
+		out[r.idx] = r.vec
+	}
+	return out, true
+}
+
+func (s SemanticStage) mergeByCosine(uf *pkgcluster.UnionFind, clusters []pkgcluster.Cluster, singletons []int, embeddings map[int][]float32) {
+	comparisons := 0
+	for i := 0; i < len(singletons); i++ {
+		for j := i + 1; j < len(singletons); j++ {
+			if s.MaxPairs > 0 && comparisons >= s.MaxPairs {
+				return
+			}
+			comparisons++
+			ci, cj := singletons[i], singletons[j]
+			if uf.Find(ci) == uf.Find(cj) {
+				continue
+			}
+			sim := cosineSimilarity(embeddings[ci], embeddings[cj])
+			if sim < s.Threshold {
+				continue
+			}
+			if antonymGuardrail(clusters[ci].Signature.RawExcerpt, clusters[cj].Signature.RawExcerpt) {
+				continue
+			}
+			uf.Union(ci, cj)
+		}
+	}
+}
+
+func rebuild(uf *pkgcluster.UnionFind, clusters []pkgcluster.Cluster) []pkgcluster.Cluster {
+	grouped := map[int][]pkgcluster.FailureInfo{}
+	groupSig := map[int]pkgcluster.ErrorSignature{}
+	for i, c := range clusters {
+		root := uf.Find(i)
+		grouped[root] = append(grouped[root], c.Failures...)
+		if _, ok := groupSig[root]; !ok {
+			groupSig[root] = c.Signature
+		}
+	}
+
+	var result []pkgcluster.Cluster
+	for root, failures := range grouped {
+		rep := failures[0]
+		for _, f := range failures[1:] {
+			if len(f.LogTail) > len(rep.LogTail) {
+				rep = f
+			}
+		}
+		result = append(result, pkgcluster.Cluster{
+			ID:             len(result) + 1,
+			Signature:      groupSig[root],
+			Failures:       failures,
+			Representative: rep,
+		})
+	}
+	return result
+}

--- a/pkg/semcluster/semantic_test.go
+++ b/pkg/semcluster/semantic_test.go
@@ -1,0 +1,167 @@
+package semcluster
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	pkgcluster "github.com/kamilpajak/heisenberg/pkg/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEmbedder returns canned vectors per input text. Thread-safe so the
+// parallel embedSingletons path can be exercised under -race.
+type fakeEmbedder struct {
+	byText map[string][]float32
+	err    error
+	calls  atomic.Int64
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	f.calls.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if v, ok := f.byText[text]; ok {
+		return v, nil
+	}
+	// Default to orthogonal-to-everything.
+	return []float32{0, 0, 1}, nil
+}
+
+func singletonCluster(id int, normalized, excerpt string) pkgcluster.Cluster {
+	sig := pkgcluster.ErrorSignature{
+		Category:   "error_message",
+		Normalized: normalized,
+		RawExcerpt: excerpt,
+	}
+	f := pkgcluster.FailureInfo{
+		JobID:     int64(id),
+		JobName:   normalized,
+		Signature: sig,
+		LogTail:   excerpt,
+	}
+	return pkgcluster.Cluster{
+		ID:             id,
+		Signature:      sig,
+		Failures:       []pkgcluster.FailureInfo{f},
+		Representative: f,
+	}
+}
+
+func TestSemanticStage_MergesNearDuplicates(t *testing.T) {
+	// A and B are cosine-close; C is orthogonal.
+	aText := ComputeClusterEmbeddingText(singletonCluster(1, "a1", "auth failed").Signature)
+	bText := ComputeClusterEmbeddingText(singletonCluster(2, "a2", "auth error").Signature)
+	cText := ComputeClusterEmbeddingText(singletonCluster(3, "different", "disk full").Signature)
+
+	embedder := &fakeEmbedder{byText: map[string][]float32{
+		aText: {1, 0, 0},
+		bText: {0.99, 0.14, 0}, // cosine ~ 0.99
+		cText: {0, 0, 1},
+	}}
+
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}
+	in := []pkgcluster.Cluster{
+		singletonCluster(1, "a1", "auth failed"),
+		singletonCluster(2, "a2", "auth error"),
+		singletonCluster(3, "different", "disk full"),
+	}
+
+	out, err := stage.Refine(context.Background(), in)
+
+	require.NoError(t, err)
+	assert.Len(t, out, 2, "A and B should merge; C untouched")
+}
+
+func TestSemanticStage_BelowThreshold_NoMerge(t *testing.T) {
+	aText := ComputeClusterEmbeddingText(singletonCluster(1, "a1", "x").Signature)
+	bText := ComputeClusterEmbeddingText(singletonCluster(2, "a2", "y").Signature)
+
+	embedder := &fakeEmbedder{byText: map[string][]float32{
+		aText: {1, 0, 0},
+		bText: {0.8, 0.6, 0}, // cosine ~ 0.80
+	}}
+
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}
+	in := []pkgcluster.Cluster{
+		singletonCluster(1, "a1", "x"),
+		singletonCluster(2, "a2", "y"),
+	}
+
+	out, err := stage.Refine(context.Background(), in)
+
+	require.NoError(t, err)
+	assert.Len(t, out, 2, "below-threshold pairs must not merge")
+}
+
+func TestSemanticStage_EmbedderError_DegradesGracefully(t *testing.T) {
+	embedder := &fakeEmbedder{err: errors.New("API down")}
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}
+	in := []pkgcluster.Cluster{
+		singletonCluster(1, "a", "x"),
+		singletonCluster(2, "b", "y"),
+	}
+
+	out, err := stage.Refine(context.Background(), in)
+
+	require.NoError(t, err, "embedder failures must not break the pipeline")
+	assert.Equal(t, in, out, "input returned unchanged on embedder error")
+}
+
+func TestSemanticStage_SkipsMultiMemberClusters(t *testing.T) {
+	// Multi-member clusters already have >1 grouping evidence; don't touch them.
+	multi := pkgcluster.Cluster{
+		ID:        1,
+		Signature: pkgcluster.ErrorSignature{Category: "error_message", Normalized: "x"},
+		Failures: []pkgcluster.FailureInfo{
+			{JobID: 10}, {JobID: 11},
+		},
+	}
+	sing := singletonCluster(2, "other", "disk full")
+
+	embedder := &fakeEmbedder{byText: map[string][]float32{}}
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}
+
+	out, err := stage.Refine(context.Background(), []pkgcluster.Cluster{multi, sing})
+
+	require.NoError(t, err)
+	assert.Len(t, out, 2)
+	assert.Equal(t, int64(0), embedder.calls.Load(), "multi-member cluster needs no embedding; only 1 singleton → no pairs")
+}
+
+func TestSemanticStage_AntonymGuardrail_VetoesOppositeOutcomes(t *testing.T) {
+	// Embeddings would say 0.99 similar, but antonym veto blocks it.
+	aCluster := singletonCluster(1, "test passed", "all tests passed")
+	bCluster := singletonCluster(2, "test failed", "test failed: auth")
+
+	embedder := &fakeEmbedder{byText: map[string][]float32{
+		ComputeClusterEmbeddingText(aCluster.Signature): {1, 0, 0},
+		ComputeClusterEmbeddingText(bCluster.Signature): {0.99, 0.14, 0},
+	}}
+
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}
+	out, err := stage.Refine(context.Background(), []pkgcluster.Cluster{aCluster, bCluster})
+
+	require.NoError(t, err)
+	assert.Len(t, out, 2, "antonym guardrail must block a passed-vs-failed merge")
+}
+
+func TestSemanticStage_SingleSingleton_Skips(t *testing.T) {
+	embedder := &fakeEmbedder{byText: map[string][]float32{}}
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}
+
+	out, err := stage.Refine(context.Background(), []pkgcluster.Cluster{
+		singletonCluster(1, "only", "x"),
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.Equal(t, int64(0), embedder.calls.Load(), "single singleton: no pair to compare, no embedding call")
+}
+
+func TestSemanticStage_NameReportsCorrectly(t *testing.T) {
+	assert.Equal(t, "semantic", SemanticStage{}.Name())
+}

--- a/pkg/semcluster/semantic_test.go
+++ b/pkg/semcluster/semantic_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const diskFullExcerpt = "disk full"
+
 // fakeEmbedder returns canned vectors per input text. Thread-safe so the
 // parallel embedSingletons path can be exercised under -race.
 type fakeEmbedder struct {
@@ -55,7 +57,7 @@ func TestSemanticStage_MergesNearDuplicates(t *testing.T) {
 	// A and B are cosine-close; C is orthogonal.
 	aText := ComputeClusterEmbeddingText(singletonCluster(1, "a1", "auth failed").Signature)
 	bText := ComputeClusterEmbeddingText(singletonCluster(2, "a2", "auth error").Signature)
-	cText := ComputeClusterEmbeddingText(singletonCluster(3, "different", "disk full").Signature)
+	cText := ComputeClusterEmbeddingText(singletonCluster(3, "different", diskFullExcerpt).Signature)
 
 	embedder := &fakeEmbedder{byText: map[string][]float32{
 		aText: {1, 0, 0},
@@ -67,7 +69,7 @@ func TestSemanticStage_MergesNearDuplicates(t *testing.T) {
 	in := []pkgcluster.Cluster{
 		singletonCluster(1, "a1", "auth failed"),
 		singletonCluster(2, "a2", "auth error"),
-		singletonCluster(3, "different", "disk full"),
+		singletonCluster(3, "different", diskFullExcerpt),
 	}
 
 	out, err := stage.Refine(context.Background(), in)
@@ -120,7 +122,7 @@ func TestSemanticStage_SkipsMultiMemberClusters(t *testing.T) {
 			{JobID: 10}, {JobID: 11},
 		},
 	}
-	sing := singletonCluster(2, "other", "disk full")
+	sing := singletonCluster(2, "other", diskFullExcerpt)
 
 	embedder := &fakeEmbedder{byText: map[string][]float32{}}
 	stage := SemanticStage{Embedder: embedder, Threshold: 0.9}

--- a/pkg/semcluster/semantic_test.go
+++ b/pkg/semcluster/semantic_test.go
@@ -167,3 +167,23 @@ func TestSemanticStage_SingleSingleton_Skips(t *testing.T) {
 func TestSemanticStage_NameReportsCorrectly(t *testing.T) {
 	assert.Equal(t, "semantic", SemanticStage{}.Name())
 }
+
+func TestSemanticStage_MaxPairs_CapsComparisons(t *testing.T) {
+	// 4 singletons with identical embeddings → 6 potential pairs, all above
+	// threshold. MaxPairs=1 caps it so only the first pair merges.
+	embedder := &fakeEmbedder{byText: map[string][]float32{}}
+	stage := SemanticStage{Embedder: embedder, Threshold: 0.0, MaxPairs: 1}
+
+	in := []pkgcluster.Cluster{
+		singletonCluster(1, "a", "a"),
+		singletonCluster(2, "b", "b"),
+		singletonCluster(3, "c", "c"),
+		singletonCluster(4, "d", "d"),
+	}
+
+	out, err := stage.Refine(context.Background(), in)
+
+	require.NoError(t, err)
+	// First pair (indices 0,1) merges; indices 2,3 untouched = 3 clusters total.
+	assert.Len(t, out, 3, "MaxPairs=1 must short-circuit after the first comparison")
+}

--- a/pkg/semcluster/text.go
+++ b/pkg/semcluster/text.go
@@ -1,0 +1,38 @@
+package semcluster
+
+import (
+	"fmt"
+	"strings"
+
+	pkgcluster "github.com/kamilpajak/heisenberg/pkg/cluster"
+)
+
+// maxEmbeddingTextLen bounds the length of the string fed to the embedding
+// model so per-cluster embedding cost stays predictable regardless of log
+// size. 500 chars ~ 125 tokens — well above the semantic signal threshold,
+// well below per-call pricing concerns.
+const maxEmbeddingTextLen = 500
+
+// ComputeClusterEmbeddingText builds a compact, deterministic textual
+// representation of a failure signature for embedding. The format is
+// stable across calls so identical signatures produce identical vectors.
+func ComputeClusterEmbeddingText(sig pkgcluster.ErrorSignature) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "category: %s\n", sig.Category)
+	if sig.RawExcerpt != "" {
+		fmt.Fprintf(&b, "error: %s\n", sig.RawExcerpt)
+	}
+	if sig.Normalized != "" {
+		fmt.Fprintf(&b, "normalized: %s\n", sig.Normalized)
+	}
+	if len(sig.TopFrames) > 0 {
+		fmt.Fprintf(&b, "top_frames: %s\n", strings.Join(sig.TopFrames, " | "))
+	}
+
+	out := b.String()
+	if len(out) > maxEmbeddingTextLen {
+		out = out[:maxEmbeddingTextLen]
+	}
+	return out
+}

--- a/pkg/semcluster/text_test.go
+++ b/pkg/semcluster/text_test.go
@@ -1,0 +1,67 @@
+package semcluster
+
+import (
+	"strings"
+	"testing"
+
+	pkgcluster "github.com/kamilpajak/heisenberg/pkg/cluster"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeClusterEmbeddingText_IncludesAllSignals(t *testing.T) {
+	sig := pkgcluster.ErrorSignature{
+		Category:   "stack_trace",
+		Normalized: "main.go: runtime error",
+		RawExcerpt: "panic: runtime error: index out of range",
+		TopFrames:  []string{"main.go:42", "handler.go:88", "router.go:15"},
+	}
+
+	out := ComputeClusterEmbeddingText(sig)
+
+	assert.Contains(t, out, "stack_trace")
+	assert.Contains(t, out, "panic: runtime error")
+	assert.Contains(t, out, "main.go: runtime error")
+	assert.Contains(t, out, "main.go:42")
+	assert.Contains(t, out, "handler.go:88")
+	assert.Contains(t, out, "router.go:15")
+}
+
+func TestComputeClusterEmbeddingText_OmitsEmptyTopFrames(t *testing.T) {
+	sig := pkgcluster.ErrorSignature{
+		Category:   "exit_code",
+		Normalized: "exit code 1",
+		RawExcerpt: "Process completed with exit code 1",
+	}
+
+	out := ComputeClusterEmbeddingText(sig)
+
+	assert.Contains(t, out, "exit_code")
+	assert.Contains(t, out, "exit code 1")
+	assert.NotContains(t, out, "top_frames:")
+}
+
+func TestComputeClusterEmbeddingText_IsDeterministic(t *testing.T) {
+	sig := pkgcluster.ErrorSignature{
+		Category:   "error_message",
+		Normalized: "connection refused",
+		RawExcerpt: "connection refused",
+		TopFrames:  []string{"a.go:1"},
+	}
+	a := ComputeClusterEmbeddingText(sig)
+	b := ComputeClusterEmbeddingText(sig)
+	assert.Equal(t, a, b)
+}
+
+func TestComputeClusterEmbeddingText_BoundedLength(t *testing.T) {
+	// Guard against accidental raw log interpolation blowing up token cost.
+	long := strings.Repeat("x", 10000)
+	sig := pkgcluster.ErrorSignature{
+		Category:   "error_message",
+		Normalized: long,
+		RawExcerpt: long,
+	}
+
+	out := ComputeClusterEmbeddingText(sig)
+
+	assert.LessOrEqual(t, len(out), maxEmbeddingTextLen, "text must be bounded for predictable embedding cost")
+}


### PR DESCRIPTION
## Summary

Adds `pkg/semcluster` implementing the `pkg/cluster.Stage` interface via Gemini embeddings + cosine similarity. Near-duplicate failures (same root cause, different error text) can now be collapsed into one cluster, cutting duplicate LLM analyses.

**Opt-in via `HEISENBERG_SEMANTIC_CLUSTERING=1`** + `GOOGLE_API_KEY`. Default behavior unchanged (zero-risk merge).

Part of #59. PR 2 of 3.

## Components

- **`SemanticStage`** — embeds all singleton clusters in parallel, pairwise cosine, union-find merge above threshold (default 0.90). Any embedder error returns input unchanged (graceful degradation).
- **Antonym guardrail** — blocks candidate merges where one side has a positive outcome token (pass/succeed/complete/ok/accepted/allowed/found/up) and the other has the matching negative. Word-boundary matching, case-insensitive. Mitigates embedding polarity conflation.
- **`GeminiEmbedder`** — minimal HTTP client for the Gemini embedding API. Duplicates a narrow slice of `ee/patterns.EmbeddingClient` so the OSS binary stays within its license boundary (`cmd/cli/` cannot import `ee/`).
- **`ComputeClusterEmbeddingText`** — deterministic, length-bounded (≤ 500 chars) text builder over category / excerpt / normalized form / top frames.

## Architecture note

Original plan put this in `ee/cluster` because it involved pgvector. This PR ships only **in-run mode** (all embeddings computed and compared within one `ClusterFailures` call, no DB writes, no cross-run caching), so there is no pgvector dependency and the license boundary check blocks `cmd/cli/` from importing `ee/`. Relocated to `pkg/semcluster`. Cross-run embedding caching deferred to a future EE extension.

## Wiring

- `analysis.Params.ClusterStages []cluster.Stage` — optional post-Jaccard stages.
- `pkg/analysis/run.go` runs `[JaccardStage, ...ClusterStages]` via `ClusterFailuresWithStages`.
- CLI builds the semantic stage when both `HEISENBERG_SEMANTIC_CLUSTERING=1` and a Google API key are present. Threshold overridable via `HEISENBERG_SEMANTIC_CLUSTER_THRESHOLD` (for calibration).

## Test plan

- [x] 19 unit tests — cosine math, antonym guardrail (pos/neg/case/word-boundary), text builder, SemanticStage (merge, below-threshold skip, embedder error, multi-member skip, antonym veto, single-singleton skip)
- [x] Race-clean under `-race -count=3` (fakeEmbedder uses atomic.Int64)
- [x] `go test ./...` green
- [ ] Live A/B eval on 171 cases in PR 3 (threshold sweep + default-on decision)