### PR TITLE
ci: async live A/B eval workflow for #58 and #59

### DIFF
--- a/.github/workflows/eval-live.yml
+++ b/.github/workflows/eval-live.yml
@@ -1,0 +1,150 @@
+name: Eval Live A/B
+
+# Live Gemini-API eval comparing baseline vs experimental feature flags.
+# VCR replay can't measure input-change effects (frozen responses), so we
+# need live calls to quantify #58 (weighted log preprocessing) and #59
+# (semantic clustering). Gemini's 503 "high demand" can make interactive
+# runs unreliable, so this workflow runs asynchronously off the dev path.
+#
+# Required repo secret:
+#   GOOGLE_API_KEY — Gemini API key for live embed + LLM calls.
+# The built-in GITHUB_TOKEN is used for GitHub artifact fetches.
+#
+# Results land in a per-variant JSON summary uploaded as a workflow artifact.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — off-peak for Gemini, before working hours.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Ground truth subset'
+        type: choice
+        options: [smoke, full]
+        default: smoke
+      variants:
+        description: 'Comma-separated variants (baseline,weighted,semantic)'
+        type: string
+        default: 'baseline,weighted,semantic'
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    name: Eval ${{ matrix.variant }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    if: ${{ github.event_name != 'workflow_dispatch' || contains(github.event.inputs.variants, matrix.variant) }}
+    strategy:
+      fail-fast: false
+      # Keep parallel=1 to stay under Gemini per-minute quotas.
+      max-parallel: 1
+      matrix:
+        variant: [baseline, weighted, semantic]
+
+    env:
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HEISENBERG_EVAL_VCR: '0'
+      HEISENBERG_EVAL_TIER: ${{ github.event.inputs.tier || 'smoke' }}
+
+    steps:
+      - name: Preflight — require GOOGLE_API_KEY
+        run: |
+          if [ -z "$GOOGLE_API_KEY" ]; then
+            echo "::error::GOOGLE_API_KEY secret not set; skipping live eval."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set variant flags
+        id: flags
+        run: |
+          case "${{ matrix.variant }}" in
+            baseline)
+              echo "env_exports=" >> "$GITHUB_OUTPUT"
+              ;;
+            weighted)
+              echo "env_exports=HEISENBERG_LOG_WEIGHTED=1" >> "$GITHUB_OUTPUT"
+              ;;
+            semantic)
+              echo "env_exports=HEISENBERG_SEMANTIC_CLUSTERING=1" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Run live eval
+        id: eval
+        run: |
+          mkdir -p eval-results
+          set -o pipefail
+          env ${{ steps.flags.outputs.env_exports }} \
+            go test ./pkg/analysis/ -tags eval \
+              -run TestEval_Suite -v -timeout 110m \
+            2>&1 | tee "eval-results/${{ matrix.variant }}.log"
+
+      - name: Extract metrics
+        if: always()
+        run: |
+          LOG="eval-results/${{ matrix.variant }}.log"
+          SUMMARY="eval-results/${{ matrix.variant }}.json"
+          MEAN=$(grep -oE 'Mean score: [0-9.]+%' "$LOG" | tail -1 | awk '{print $3}' || echo "null")
+          CAT=$(grep -oE 'Category accuracy: [0-9.]+%' "$LOG" | tail -1 | awk '{print $3}' || echo "null")
+          SCORED=$(grep -cE '^\s*eval_test\.go:.*score=' "$LOG" || true)
+          cat > "$SUMMARY" <<EOF
+          {
+            "variant": "${{ matrix.variant }}",
+            "tier": "${HEISENBERG_EVAL_TIER}",
+            "mean_score": "$MEAN",
+            "category_accuracy": "$CAT",
+            "cases_scored": $SCORED,
+            "run_id": "${{ github.run_id }}",
+            "commit_sha": "${{ github.sha }}"
+          }
+          EOF
+          cat "$SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-${{ matrix.variant }}
+          path: eval-results/
+          retention-days: 90
+
+  summary:
+    name: Eval summary
+    needs: eval
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          path: results/
+          pattern: eval-*
+          merge-multiple: true
+
+      - name: Write combined summary
+        run: |
+          echo "## Eval A/B results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Variant | Mean score | Category accuracy | Cases |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          for f in results/*.json; do
+            [ -f "$f" ] || continue
+            V=$(jq -r '.variant' "$f")
+            M=$(jq -r '.mean_score' "$f")
+            C=$(jq -r '.category_accuracy' "$f")
+            N=$(jq -r '.cases_scored' "$f")
+            echo "| $V | $M | $C | $N |" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/eval-live.yml
+++ b/.github/workflows/eval-live.yml
@@ -28,14 +28,13 @@ on:
         type: string
         default: 'baseline,weighted,semantic'
 
-permissions:
-  contents: read
-
 jobs:
   eval:
     name: Eval ${{ matrix.variant }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: read
     if: ${{ github.event_name != 'workflow_dispatch' || contains(github.event.inputs.variants, matrix.variant) }}
     strategy:
       fail-fast: false
@@ -126,6 +125,8 @@ jobs:
     needs: eval
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      contents: read
     steps:
       - name: Download all results
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Adds `.github/workflows/eval-live.yml`: a scheduled + manual-trigger workflow that runs live Gemini eval across three variants (baseline, `HEISENBERG_LOG_WEIGHTED=1`, `HEISENBERG_SEMANTIC_CLUSTERING=1`), uploads per-variant logs and JSON metrics as artifacts, and aggregates them into the run's Job Summary.

## Why

- VCR replay can't measure input-change effects (responses are frozen) — confirmed on #58.
- Live eval from a dev machine hits Gemini 503 "high demand" enough to blow interactive test timeouts.
- Moving measurement off the dev critical path unblocks #60–#63 (Trunk taxonomy, test health scoring, co-occurrence clustering, custom fingerprinting) — none need to wait on API stability for their feature work to ship behind flags.

## What it does

- Monday 06:00 UTC cron (off-peak) + on-demand via `workflow_dispatch` with `tier` (smoke/full) and `variants` (subset) inputs.
- Matrix job with `max-parallel: 1` to stay under per-minute Gemini quotas.
- Each variant: runs `TestEval_Suite` with `HEISENBERG_EVAL_VCR=0`, captures log, extracts `Mean score` + `Category accuracy` + case count into JSON, uploads as artifact.
- Summary job renders a markdown table into `$GITHUB_STEP_SUMMARY`.

## One-time setup

- Set a `GOOGLE_API_KEY` repo secret (not pushed in this PR). The preflight step fails fast with a clear message if absent.
- `GITHUB_TOKEN` is auto-provided.

## Test plan

- [x] YAML lints (no syntax errors)
- [ ] After merge: manual `workflow_dispatch` run on `main` with `tier=smoke` to validate the full pipeline on three variants
- [ ] Confirm artifact upload + Job Summary rendering
- [ ] Evaluate whether the smoke window is wide enough, or whether threshold sweeps (for PR 3 of #59) need a dedicated workflow

## Followups

- PR 3 of #59: threshold sweep (0.95/0.90/0.88/0.85). Can extend this workflow with a matrix over thresholds, or split into a separate workflow to avoid quota saturation.