### PR TITLE
fix(logclean): boost assertion-detail lines to weight 3

### DIFF
--- a/pkg/logclean/weighted.go
+++ b/pkg/logclean/weighted.go
@@ -19,6 +19,7 @@ var criticalPrefixes = []string{
 	"panic:",
 	"Traceback",
 	"##[error]",
+	"AssertionError",
 }
 
 var criticalRegexes = []*regexp.Regexp{
@@ -44,6 +45,16 @@ var warningContains = []string{
 	"OOMKilled",
 	"connection refused",
 	"connection reset",
+}
+
+// warningRegexes catch assertion-detail patterns that carry critical
+// diagnostic context but don't fit the contains-list style (need anchors or
+// captures). Elevating these above default-signal keeps them from losing
+// budget pressure to bulk (pass)/build filler.
+var warningRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`^(Expected|Received):`),      // jest/vitest/jasmine/pytest assertion diff
+	regexp.MustCompile(`(?i)expected\s.+\sbut\sgot`), // "expected X but got Y"
+	regexp.MustCompile(`^\s*assert\s[A-Za-z_(]`),     // `assert foo == bar`
 }
 
 var warningContainsLower = func() []string {
@@ -78,6 +89,11 @@ func classifyWeight(line string) int {
 	lower := strings.ToLower(line)
 	for _, s := range warningContainsLower {
 		if strings.Contains(lower, s) {
+			return weightWarning
+		}
+	}
+	for _, re := range warningRegexes {
+		if re.MatchString(line) {
 			return weightWarning
 		}
 	}

--- a/pkg/logclean/weighted_test.go
+++ b/pkg/logclean/weighted_test.go
@@ -45,6 +45,23 @@ func TestClassifyWeight_Warning(t *testing.T) {
 	}
 }
 
+func TestClassifyWeight_AssertionDetail(t *testing.T) {
+	// Assertion-detail lines carry the specific failure context that the LLM
+	// needs to diagnose failure_type=assertion. Under budget pressure they
+	// must outrank generic (pass)/build filler (weight 1).
+	lines := []string{
+		`Expected: "https://evm-rpc.sei-apis.com"`,
+		`Received: "https://rpc.example.com"`,
+		`AssertionError: assert 500 == 200`,
+		`assert response.status_code == 200`,
+		`expected 42 but got 7`,
+	}
+	for _, line := range lines {
+		assert.GreaterOrEqual(t, classifyWeight(line), weightWarning,
+			"assertion detail must rank at least warning weight: %q", line)
+	}
+}
+
 func TestClassifyWeight_NoiseFilteredByCaller(t *testing.T) {
 	// classifyWeight's contract: caller filters noise via classifyLine first.
 	// This test documents that contract — noise lines are dropped upstream.


### PR DESCRIPTION
## Summary

First live A/B run of #64 (weighted preprocessing) on 30 smoke cases showed an 8.5pp paired regression vs tail-truncate baseline. Root-caused to assertion-detail lines (\`Expected:\`/\`Received:\`/\`AssertionError\`/\`assert …\`) falling to weight 1 and losing to bulk \`(pass)\` test filler. Fix boosts those patterns above default-signal.

## Evidence

Worst regression: \`Monaco-Research/monaco-sdk/23952316756\` — baseline 1.00, weighted 0.00.

Ground truth: \`failure_type=assertion, bug_location=production\`.

Log content that weighted was dropping:
\`\`\`
Expected: \"https://evm-rpc.sei-apis.com\"
Received: \"https://rpc.example.com\"
\`\`\`

Manual diff on the fixture at budget=30KB confirms weighted now preserves \`Received:\` lines after the fix.

## Patterns elevated

| Pattern | New weight |
|---|---|
| \`AssertionError\` prefix | 10 (critical) |
| \`^Expected:\` / \`^Received:\` | 3 (warning) |
| \`(?i)expected X but got Y\` | 3 (warning) |
| \`^\\s*assert <expr>\` | 3 (warning) |

## Test plan

- [x] New \`TestClassifyWeight_AssertionDetail\` covers all four pattern families; red-before-fix confirmed
- [x] Existing logclean tests still green
- [ ] After merge: re-trigger \`eval-live.yml\` workflow, check paired delta improves vs baseline

## Next

If the next live run still shows regression on weighted, escalate to option B (keep flag permanently OFF, revisit with larger pattern catalog).