### PR TITLE
feat(llm): quota circuit-breaker — stop eval after N consecutive 429s

### DIFF
--- a/pkg/analysis/eval_test.go
+++ b/pkg/analysis/eval_test.go
@@ -32,6 +32,12 @@ const (
 	// vcrReplayPlaceholder is used as a stand-in credential value when tests run
 	// in VCR replay mode — cassettes provide responses, so real tokens aren't needed.
 	vcrReplayPlaceholder = "vcr-replay"
+
+	// maxConsecutiveQuotaStrikes stops the eval loop after this many consecutive
+	// Gemini 429 errors. Daily quota exhaustion (#68 root-cause) can burn
+	// thousands of retries otherwise; circuit-breaking preserves quota for
+	// the next scheduled run instead.
+	maxConsecutiveQuotaStrikes = 3
 )
 
 // groundTruth defines expected results for an eval test case.
@@ -678,10 +684,23 @@ func TestEval_Suite(t *testing.T) {
 	useVCR := os.Getenv("HEISENBERG_EVAL_RECORD") == "1" || os.Getenv("HEISENBERG_EVAL_VCR") != "0"
 	googleAPIKey := resolveGoogleAPIKey(useVCR)
 
+	quotaStrikes := 0
 	for _, gt := range cases {
 		gt := gt
+		if quotaStrikes >= maxConsecutiveQuotaStrikes {
+			t.Logf("CIRCUIT OPEN: skipping %s/%d after %d consecutive quota errors",
+				gt.Repo, gt.RunID, quotaStrikes)
+			report.addCategoryResult(false)
+			report.addCaseScore(0)
+			continue
+		}
 		t.Run(fmt.Sprintf("%s/%d", gt.Repo, gt.RunID), func(t *testing.T) {
-			runEvalCase(t, gt, model, googleAPIKey, logPath, useVCR, &report)
+			err := runEvalCase(t, gt, model, googleAPIKey, logPath, useVCR, &report)
+			if llm.IsQuotaExhausted(err) {
+				quotaStrikes++
+			} else {
+				quotaStrikes = 0
+			}
 		})
 	}
 
@@ -728,12 +747,15 @@ func resolveGoogleAPIKey(useVCR bool) string {
 }
 
 // runEvalCase executes a single eval case under the given environment.
+// Returns the error from analysis.Run so the caller can react to quota
+// exhaustion via a circuit breaker; the returned error is nil when the
+// case was scored (or skipped because a cassette exists).
 func runEvalCase(t *testing.T, gt groundTruth, model, googleAPIKey, logPath string,
-	useVCR bool, report *evalReport) {
+	useVCR bool, report *evalReport) error {
 	cassetteName := strings.ReplaceAll(gt.Repo, "/", "_") + "_" + fmt.Sprint(gt.RunID)
 
 	if skipIfCassetteExists(t, cassetteName) {
-		return
+		return nil
 	}
 
 	var vcrClient *http.Client
@@ -766,10 +788,11 @@ func runEvalCase(t *testing.T, gt groundTruth, model, googleAPIKey, logPath stri
 		t.Logf("ERROR: %v", err)
 		report.addCategoryResult(false)
 		report.addCaseScore(0)
-		return
+		return err
 	}
 
 	scoreAndLog(t, gt, result, model, logPath, report)
+	return nil
 }
 
 // skipIfCassetteExists skips the test in record mode if a cassette already exists.

--- a/pkg/llm/errors.go
+++ b/pkg/llm/errors.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -82,6 +83,21 @@ func (e *APIError) hint429WithRetries(prefix string) string {
 	}
 	parts = append(parts, "Check usage at ai.google.dev")
 	return strings.Join(parts, " ")
+}
+
+// IsQuotaExhausted reports whether err is (or wraps) an APIError with HTTP 429.
+// 429 covers both per-minute rate limits and exhausted daily quotas; callers
+// that want to stop firing more requests after repeated quota hits should use
+// this as their circuit-breaker signal.
+func IsQuotaExhausted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == 429
 }
 
 // ConfigError represents a configuration problem (e.g. missing API key).

--- a/pkg/llm/errors_test.go
+++ b/pkg/llm/errors_test.go
@@ -149,6 +149,27 @@ func TestRoundHours(t *testing.T) {
 	}
 }
 
+func TestIsQuotaExhausted(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("something"), false},
+		{"APIError 429", &APIError{StatusCode: 429}, true},
+		{"APIError 429 wrapped", fmt.Errorf("wrap: %w", &APIError{StatusCode: 429}), true},
+		{"APIError 500", &APIError{StatusCode: 500}, false},
+		{"APIError 503", &APIError{StatusCode: 503}, false},
+		{"APIError 401", &APIError{StatusCode: 401}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsQuotaExhausted(tt.err))
+		})
+	}
+}
+
 func TestAPIError_ErrorsAs(t *testing.T) {
 	apiErr := parseAPIError(429, status429, []byte(`{}`))
 	wrapped := fmt.Errorf("step 4: %w", apiErr)


### PR DESCRIPTION
## Summary

Adds \`llm.IsQuotaExhausted(err)\` helper + a consecutive-strike counter in the eval harness. When 3 cases in a row return HTTP 429 from Gemini, the remaining cases short-circuit with a 0 score instead of continuing to burn retries against an exhausted quota.

## Motivation

First live A/B smoke run (30 cases × 3 variants) burned the daily Gemini free-tier quota. Each subsequent case still fired 5 retries × 5s backoff against an already-exhausted quota — wasting 25s per case with no possibility of success. The follow-up run (#68 validation) failed with baseline=7/30, weighted=0/30, semantic=0/30 because of exactly this pattern.

With the breaker:
- Quota exhaustion is detected after 3 consecutive strikes (handles one-off 429s from burstiness).
- Remaining cases report 0 without HTTP calls → run ends in minutes instead of hours.
- Log lines emit \`CIRCUIT OPEN: skipping X/Y after 3 consecutive quota errors\` so the operator knows.

## TDD

- \`pkg/llm.IsQuotaExhausted\` has unit tests for nil / plain error / 429 / 429-wrapped / 500 / 503 / 401.
- The eval harness change is exercised end-to-end under replay mode (171 cases in 8s still passes); the circuit only triggers on live 429s.

## What this doesn't do

- Doesn't distinguish per-minute rate limits from daily quota exhaustion. Both return 429; both warrant backing off. The scheduled Monday run will retry from scratch either way.
- Doesn't change retry behavior inside \`pkg/llm.generate\` — per-request retries still happen; we just stop firing new requests at the orchestrator level.

## Test plan

- [x] \`go test ./pkg/llm/\` green (new tests)
- [x] \`go test -tags eval ./pkg/analysis/ -run TestEval_Suite\` passes under VCR replay (8s)
- [ ] Post-merge: next live \`eval-live.yml\` run should surface \`CIRCUIT OPEN\` lines if quota's still exhausted, rather than silently burning hours

Part of #57.